### PR TITLE
Add Japanese kanji, hiragana, fullwidth symbols to table formatting.

### DIFF
--- a/src/tableFormatter.ts
+++ b/src/tableFormatter.ts
@@ -68,7 +68,7 @@ class MarkdownDocumentFormatter implements DocumentFormattingEditProvider {
             }
         });
         let colWidth = Array(content[0].length).fill(3);
-        let cn = /[\u4e00-\u9eff，。《》？；：‘“’”（）【】、—]/g;
+        let cn = /[\u3000-\u9fff\uff01-\uff60‘“’”—]/g;
         content.forEach(row => {
             row.forEach((cell, i) => {
                 // Treat Chinese characters as 2 English characters


### PR DESCRIPTION
Full-width Japanese characters, Full-width symbols
I would like you to add it to the table shaping.
