### PR TITLE
WIP: math completion trigger improvements

### DIFF
--- a/src/completion.ts
+++ b/src/completion.ts
@@ -112,8 +112,8 @@ class MdCompletionItemProvider implements CompletionItemProvider {
                 })
             );
         } else if (
-            (matches = lineTextBefore.match(/\\+$/)) !== null
-            && matches[0].length % 2 !== 0
+            (matches = lineTextBefore.match(/(\\+)\w*$/)) !== null
+            && matches[1].length % 2 !== 0
         ) {
             if (
                 /(^|[^\$])\$(|[^ \$].*)\\\w*$/.test(lineTextBefore)

--- a/src/completion.ts
+++ b/src/completion.ts
@@ -80,11 +80,11 @@ class MdCompletionItemProvider implements CompletionItemProvider {
 
         let matches;
         matches = lineTextBefore.match(/\\+$/);
-        if (/!\[[^\]]*?\]\([^\)]*$/.test(lineTextBefore)) {
+        if (/!\[[^\[\]]*?\]\([^\)]*$/.test(lineTextBefore)) {
             // Complete image paths
             if (workspace.getWorkspaceFolder(document.uri) === undefined) return [];
 
-            matches = lineTextBefore.match(/!\[[^\]]*?\]\(([^\)]*?)[\\\/]?[^\\\/\)]*$/);
+            matches = lineTextBefore.match(/!\[[^\[\]]*?\]\(([^\)]*?)[\\\/]?[^\\\/\)]*$/);
             let dir = matches[1].replace(/\\/g, '/');
 
             return workspace.findFiles((dir.length == 0 ? '' : dir + '/') + '**/*.{png,jpg,jpeg,svg,gif}', '**/node_modules/**').then(uris =>


### PR DESCRIPTION
This includes 3 things:

- Small fix extending image regex to not match links
- Allow manually triggering math completions (`ctrl+space`) after a partial command (closes #331)
- A WIP to allow `ctrl+space` even without `\`. I have not solved all edge cases (see comment on commit 781c305) and I generally would like a review on the refactoring in case you would keep this change.

I also have some ideas to improve the math completions by
- providing `documentation` (some explanation and preview for symbols) for `CompletionItem`s.
- improving (?) the usability of `delimiterSizing`s by turning them into environments (also add `\right` when adding `\left`) and add `(`, `[`, ... as `commitCharacters`.

But if you want to merge sooner than I can delay and make a new PR later.