### PR TITLE
(WIP) allow custom TOC templates

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# EditorConfig is awesome: http://EditorConfig.org
+root = true
+
+# Apply to every file
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{ts,js,json}]
+indent_style = space
+indent_size = 4

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,11 +1,12 @@
 // Place your settings in this file to overwrite default and user settings.
 {
-    "files.exclude": {
-        "out": false // set this to true to hide the "out" folder with the compiled JS files
-    },
-    "search.exclude": {
-        "out": true // set this to false to include "out" folder in search results
-    },
-    // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
-    "typescript.tsc.autoDetect": "off"
+  "files.exclude": {
+    "out": false // set this to true to hide the "out" folder with the compiled JS files
+  },
+  "search.exclude": {
+    "out": true // set this to false to include "out" folder in search results
+  },
+  // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
+  "typescript.tsc.autoDetect": "off",
+  "editor.formatOnSave": false
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,12 +1,11 @@
 // Place your settings in this file to overwrite default and user settings.
 {
-  "files.exclude": {
-    "out": false // set this to true to hide the "out" folder with the compiled JS files
-  },
-  "search.exclude": {
-    "out": true // set this to false to include "out" folder in search results
-  },
-  // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
-  "typescript.tsc.autoDetect": "off",
-  "editor.formatOnSave": false
+    "files.exclude": {
+        "out": false // set this to true to hide the "out" folder with the compiled JS files
+    },
+    "search.exclude": {
+        "out": true // set this to false to include "out" folder in search results
+    },
+    // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
+    "typescript.tsc.autoDetect": "off"
 }

--- a/package.json
+++ b/package.json
@@ -182,16 +182,16 @@
             "title": "%config.title%",
             "properties": {
                 "markdown.extension.toc.marker": {
-                  "type": "string",
-                  "default": "·"
+                    "type": "string",
+                    "default": "·"
                 },
                 "markdown.extension.toc.markerSkipLast": {
-                  "type": "boolean",
-                  "default": true
+                    "type": "boolean",
+                    "default": true
                 },
                 "markdown.extension.toc.template": {
-                  "type": "string",
-                  "default": "{marker} [{name}]({link})"
+                    "type": "string",
+                    "default": "{marker} [{name}]({link})"
                 },
                 "markdown.extension.toc.levels": {
                     "type": "string",

--- a/package.json
+++ b/package.json
@@ -1,355 +1,367 @@
 {
-    "name": "markdown-all-in-one",
-    "displayName": "%ext.displayName%",
-    "description": "%ext.description%",
-    "icon": "images/Markdown-mark.png",
-    "version": "2.1.1",
-    "publisher": "yzhang",
-    "engines": {
-        "vscode": "^1.30.2"
-    },
-    "categories": [
-        "Other"
+  "name": "markdown-all-in-one",
+  "version": "2.1.1",
+  "description": "%ext.description%",
+  "keywords": [
+    "markdown"
+  ],
+  "bugs": {
+    "url": "https://github.com/yzhang-gh/vscode-markdown/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/yzhang-gh/vscode-markdown"
+  },
+  "license": "MIT",
+  "main": "./dist/extension",
+  "scripts": {
+    "compile": "webpack --mode none",
+    "postinstall": "node ./node_modules/vscode/bin/install",
+    "test": "tsc -p ./ && node ./node_modules/vscode/bin/test",
+    "test-compile": "tsc -p ./",
+    "vscode:prepublish": "webpack --mode production",
+    "watch": "webpack --mode none --watch"
+  },
+  "dependencies": {
+    "@neilsustc/markdown-it-katex": "^0.3.0",
+    "highlight.js": "^9.15.6",
+    "image-size": "^0.7.2",
+    "markdown-it": "^8.4.2",
+    "markdown-it-task-lists": "^2.1.1",
+    "string-similarity": "^3.0.0"
+  },
+  "devDependencies": {
+    "@types/highlight.js": "^9.12.3",
+    "@types/image-size": "^0.7.0",
+    "@types/markdown-it": "^0.0.7",
+    "@types/mocha": "^5.2.6",
+    "@types/node": "^11.11.3",
+    "mocha": "^6.0.2",
+    "ts-loader": "^5.3.3",
+    "typescript": "^3.3.3333",
+    "vscode": "^1.1.30",
+    "webpack": "^4.29.6",
+    "webpack-cli": "^3.2.3"
+  },
+  "engines": {
+    "vscode": "^1.30.2"
+  },
+  "activationEvents": [
+    "onLanguage:markdown",
+    "workspaceContains:README.md"
+  ],
+  "categories": [
+    "Other"
+  ],
+  "contributes": {
+    "commands": [
+      {
+        "command": "markdown.extension.toc.create",
+        "title": "%command.toc.create.title%"
+      },
+      {
+        "command": "markdown.extension.toc.update",
+        "title": "%command.toc.update.title%"
+      },
+      {
+        "command": "markdown.extension.printToHtml",
+        "title": "%command.printToHtml.title%"
+      },
+      {
+        "command": "markdown.extension.editing.toggleCodeSpan",
+        "title": "%command.editing.toggleCodeSpan.title%"
+      },
+      {
+        "command": "markdown.extension.editing.toggleMath",
+        "title": "%command.editing.toggleMath.title%"
+      },
+      {
+        "command": "markdown.extension.editing.toggleUnorderedList",
+        "title": "%command.editing.toggleUnorderedList.title%"
+      }
     ],
-    "keywords": [
-        "markdown"
+    "keybindings": [
+      {
+        "command": "markdown.extension.editing.toggleBold",
+        "key": "ctrl+b",
+        "mac": "cmd+b",
+        "when": "editorTextFocus && !editorReadonly && editorLangId == markdown"
+      },
+      {
+        "command": "markdown.extension.editing.toggleItalic",
+        "key": "ctrl+i",
+        "mac": "cmd+i",
+        "when": "editorTextFocus && !editorReadonly && editorLangId == markdown"
+      },
+      {
+        "command": "markdown.extension.editing.toggleStrikethrough",
+        "key": "alt+s",
+        "when": "editorTextFocus && !editorReadonly && editorLangId == markdown && !isMac"
+      },
+      {
+        "command": "markdown.extension.editing.toggleHeadingUp",
+        "key": "ctrl+shift+]",
+        "mac": "ctrl+shift+]",
+        "when": "editorTextFocus && !editorReadonly && editorLangId == markdown"
+      },
+      {
+        "command": "markdown.extension.editing.toggleHeadingDown",
+        "key": "ctrl+shift+[",
+        "mac": "ctrl+shift+[",
+        "when": "editorTextFocus && !editorReadonly && editorLangId == markdown"
+      },
+      {
+        "command": "markdown.extension.editing.toggleMath",
+        "key": "ctrl+m",
+        "mac": "cmd+m",
+        "when": "editorTextFocus && !editorReadonly && editorLangId == markdown"
+      },
+      {
+        "command": "markdown.extension.onEnterKey",
+        "key": "enter",
+        "when": "editorTextFocus && !editorReadonly && editorLangId == markdown && !suggestWidgetVisible && vim.mode != 'Normal' && vim.mode != 'Visual' && vim.mode != 'VisualBlock' && vim.mode != 'VisualLine' && vim.mode != 'SearchInProgressMode' && vim.mode != 'CommandlineInProgress' && vim.mode != 'Replace' && vim.mode != 'EasyMotionMode' && vim.mode != 'EasyMotionInputMode' && vim.mode != 'SurroundInputMode'"
+      },
+      {
+        "command": "markdown.extension.onCtrlEnterKey",
+        "key": "ctrl+enter",
+        "mac": "cmd+enter",
+        "when": "editorTextFocus && !editorReadonly && editorLangId == markdown && !suggestWidgetVisible"
+      },
+      {
+        "command": "markdown.extension.onShiftEnterKey",
+        "key": "shift+enter",
+        "when": "editorTextFocus && !editorReadonly && editorLangId == markdown && !suggestWidgetVisible"
+      },
+      {
+        "command": "markdown.extension.onTabKey",
+        "key": "tab",
+        "when": "editorTextFocus && !editorReadonly && editorLangId == markdown && !suggestWidgetVisible && !editorTabMovesFocus && !inSnippetMode && !hasSnippetCompletions && !hasOtherSuggestions"
+      },
+      {
+        "command": "markdown.extension.onShiftTabKey",
+        "key": "shift+tab",
+        "when": "editorTextFocus && !editorReadonly && editorLangId == markdown && !suggestWidgetVisible && !editorTabMovesFocus && !inSnippetMode && !hasSnippetCompletions && !hasOtherSuggestions"
+      },
+      {
+        "command": "markdown.extension.onBackspaceKey",
+        "key": "backspace",
+        "when": "editorTextFocus && !editorReadonly && editorLangId == markdown && !suggestWidgetVisible && vim.mode != 'Normal' && vim.mode != 'Visual' && vim.mode != 'VisualBlock' && vim.mode != 'VisualLine' && vim.mode != 'SearchInProgressMode' && vim.mode != 'CommandlineInProgress' && vim.mode != 'Replace' && vim.mode != 'EasyMotionMode' && vim.mode != 'EasyMotionInputMode' && vim.mode != 'SurroundInputMode'"
+      },
+      {
+        "command": "markdown.extension.onMoveLineUp",
+        "key": "alt+up",
+        "when": "editorTextFocus && !editorReadonly && editorLangId == markdown && !suggestWidgetVisible"
+      },
+      {
+        "command": "markdown.extension.onMoveLineDown",
+        "key": "alt+down",
+        "when": "editorTextFocus && !editorReadonly && editorLangId == markdown && !suggestWidgetVisible"
+      },
+      {
+        "command": "markdown.extension.onCopyLineUp",
+        "key": "shift+alt+up",
+        "when": "editorTextFocus && !editorReadonly && editorLangId == markdown && !suggestWidgetVisible"
+      },
+      {
+        "command": "markdown.extension.onCopyLineDown",
+        "key": "shift+alt+down",
+        "when": "editorTextFocus && !editorReadonly && editorLangId == markdown && !suggestWidgetVisible"
+      },
+      {
+        "command": "markdown.extension.onIndentLines",
+        "key": "ctrl+]",
+        "mac": "cmd+]",
+        "when": "editorTextFocus && editorLangId == markdown && !suggestWidgetVisible"
+      },
+      {
+        "command": "markdown.extension.onOutdentLines",
+        "key": "ctrl+[",
+        "mac": "cmd+[",
+        "when": "editorTextFocus && editorLangId == markdown && !suggestWidgetVisible"
+      },
+      {
+        "command": "markdown.extension.checkTaskList",
+        "key": "alt+c",
+        "when": "editorTextFocus && editorLangId == markdown"
+      },
+      {
+        "command": "markdown.extension.togglePreview",
+        "key": "ctrl+shift+v",
+        "mac": "cmd+shift+v",
+        "when": "!terminalFocus"
+      },
+      {
+        "command": "markdown.extension.togglePreviewToSide",
+        "key": "ctrl+k v",
+        "mac": "cmd+k v",
+        "when": "!terminalFocus"
+      },
+      {
+        "command": "markdown.extension.editing.paste",
+        "key": "ctrl+v",
+        "mac": "cmd+v",
+        "when": "editorTextFocus && editorLangId == markdown && editorHasSelection"
+      }
     ],
-    "bugs": {
-        "url": "https://github.com/yzhang-gh/vscode-markdown/issues"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/yzhang-gh/vscode-markdown"
-    },
-    "license": "MIT",
-    "activationEvents": [
-        "onLanguage:markdown",
-        "workspaceContains:README.md"
-    ],
-    "main": "./dist/extension",
-    "contributes": {
-        "commands": [
-            {
-                "command": "markdown.extension.toc.create",
-                "title": "%command.toc.create.title%"
-            },
-            {
-                "command": "markdown.extension.toc.update",
-                "title": "%command.toc.update.title%"
-            },
-            {
-                "command": "markdown.extension.printToHtml",
-                "title": "%command.printToHtml.title%"
-            },
-            {
-                "command": "markdown.extension.editing.toggleCodeSpan",
-                "title": "%command.editing.toggleCodeSpan.title%"
-            },
-            {
-                "command": "markdown.extension.editing.toggleMath",
-                "title": "%command.editing.toggleMath.title%"
-            },
-            {
-                "command": "markdown.extension.editing.toggleUnorderedList",
-                "title": "%command.editing.toggleUnorderedList.title%"
-            }
-        ],
-        "keybindings": [
-            {
-                "command": "markdown.extension.editing.toggleBold",
-                "key": "ctrl+b",
-                "mac": "cmd+b",
-                "when": "editorTextFocus && !editorReadonly && editorLangId == markdown"
-            },
-            {
-                "command": "markdown.extension.editing.toggleItalic",
-                "key": "ctrl+i",
-                "mac": "cmd+i",
-                "when": "editorTextFocus && !editorReadonly && editorLangId == markdown"
-            },
-            {
-                "command": "markdown.extension.editing.toggleStrikethrough",
-                "key": "alt+s",
-                "when": "editorTextFocus && !editorReadonly && editorLangId == markdown && !isMac"
-            },
-            {
-                "command": "markdown.extension.editing.toggleHeadingUp",
-                "key": "ctrl+shift+]",
-                "mac": "ctrl+shift+]",
-                "when": "editorTextFocus && !editorReadonly && editorLangId == markdown"
-            },
-            {
-                "command": "markdown.extension.editing.toggleHeadingDown",
-                "key": "ctrl+shift+[",
-                "mac": "ctrl+shift+[",
-                "when": "editorTextFocus && !editorReadonly && editorLangId == markdown"
-            },
-            {
-                "command": "markdown.extension.editing.toggleMath",
-                "key": "ctrl+m",
-                "mac": "cmd+m",
-                "when": "editorTextFocus && !editorReadonly && editorLangId == markdown"
-            },
-            {
-                "command": "markdown.extension.onEnterKey",
-                "key": "enter",
-                "when": "editorTextFocus && !editorReadonly && editorLangId == markdown && !suggestWidgetVisible && vim.mode != 'Normal' && vim.mode != 'Visual' && vim.mode != 'VisualBlock' && vim.mode != 'VisualLine' && vim.mode != 'SearchInProgressMode' && vim.mode != 'CommandlineInProgress' && vim.mode != 'Replace' && vim.mode != 'EasyMotionMode' && vim.mode != 'EasyMotionInputMode' && vim.mode != 'SurroundInputMode'"
-            },
-            {
-                "command": "markdown.extension.onCtrlEnterKey",
-                "key": "ctrl+enter",
-                "mac": "cmd+enter",
-                "when": "editorTextFocus && !editorReadonly && editorLangId == markdown && !suggestWidgetVisible"
-            },
-            {
-                "command": "markdown.extension.onShiftEnterKey",
-                "key": "shift+enter",
-                "when": "editorTextFocus && !editorReadonly && editorLangId == markdown && !suggestWidgetVisible"
-            },
-            {
-                "command": "markdown.extension.onTabKey",
-                "key": "tab",
-                "when": "editorTextFocus && !editorReadonly && editorLangId == markdown && !suggestWidgetVisible && !editorTabMovesFocus && !inSnippetMode && !hasSnippetCompletions && !hasOtherSuggestions"
-            },
-            {
-                "command": "markdown.extension.onShiftTabKey",
-                "key": "shift+tab",
-                "when": "editorTextFocus && !editorReadonly && editorLangId == markdown && !suggestWidgetVisible && !editorTabMovesFocus && !inSnippetMode && !hasSnippetCompletions && !hasOtherSuggestions"
-            },
-            {
-                "command": "markdown.extension.onBackspaceKey",
-                "key": "backspace",
-                "when": "editorTextFocus && !editorReadonly && editorLangId == markdown && !suggestWidgetVisible && vim.mode != 'Normal' && vim.mode != 'Visual' && vim.mode != 'VisualBlock' && vim.mode != 'VisualLine' && vim.mode != 'SearchInProgressMode' && vim.mode != 'CommandlineInProgress' && vim.mode != 'Replace' && vim.mode != 'EasyMotionMode' && vim.mode != 'EasyMotionInputMode' && vim.mode != 'SurroundInputMode'"
-            },
-            {
-                "command": "markdown.extension.onMoveLineUp",
-                "key": "alt+up",
-                "when": "editorTextFocus && !editorReadonly && editorLangId == markdown && !suggestWidgetVisible"
-            },
-            {
-                "command": "markdown.extension.onMoveLineDown",
-                "key": "alt+down",
-                "when": "editorTextFocus && !editorReadonly && editorLangId == markdown && !suggestWidgetVisible"
-            },
-            {
-                "command": "markdown.extension.onCopyLineUp",
-                "key": "shift+alt+up",
-                "when": "editorTextFocus && !editorReadonly && editorLangId == markdown && !suggestWidgetVisible"
-            },
-            {
-                "command": "markdown.extension.onCopyLineDown",
-                "key": "shift+alt+down",
-                "when": "editorTextFocus && !editorReadonly && editorLangId == markdown && !suggestWidgetVisible"
-            },
-            {
-                "command": "markdown.extension.onIndentLines",
-                "key": "ctrl+]",
-                "mac": "cmd+]",
-                "when": "editorTextFocus && editorLangId == markdown && !suggestWidgetVisible"
-            },
-            {
-                "command": "markdown.extension.onOutdentLines",
-                "key": "ctrl+[",
-                "mac": "cmd+[",
-                "when": "editorTextFocus && editorLangId == markdown && !suggestWidgetVisible"
-            },
-            {
-                "command": "markdown.extension.checkTaskList",
-                "key": "alt+c",
-                "when": "editorTextFocus && editorLangId == markdown"
-            },
-            {
-                "command": "markdown.extension.togglePreview",
-                "key": "ctrl+shift+v",
-                "mac": "cmd+shift+v",
-                "when": "!terminalFocus"
-            },
-            {
-                "command": "markdown.extension.togglePreviewToSide",
-                "key": "ctrl+k v",
-                "mac": "cmd+k v",
-                "when": "!terminalFocus"
-            },
-            {
-                "command": "markdown.extension.editing.paste",
-                "key": "ctrl+v",
-                "mac": "cmd+v",
-                "when": "editorTextFocus && editorLangId == markdown && editorHasSelection"
-            }
-        ],
-        "configuration": {
-            "type": "object",
-            "title": "%config.title%",
-            "properties": {
-                "markdown.extension.toc.levels": {
-                    "type": "string",
-                    "default": "1..6",
-                    "description": "%config.toc.levels.description%"
-                },
-                "markdown.extension.toc.orderedList": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "%config.toc.orderedList.description%"
-                },
-                "markdown.extension.toc.unorderedList.marker": {
-                    "type": "string",
-                    "default": "-",
-                    "description": "%config.toc.unorderedList.marker.description%",
-                    "enum": [
-                        "-",
-                        "*",
-                        "+"
-                    ]
-                },
-                "markdown.extension.toc.plaintext": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "%config.toc.plaintext.description%"
-                },
-                "markdown.extension.toc.updateOnSave": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "%config.toc.updateOnSave.description%"
-                },
-                "markdown.extension.toc.githubCompatibility": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "%config.toc.githubCompatibility.description%"
-                },
-                "markdown.extension.list.indentationSize": {
-                    "type": "string",
-                    "enum": [
-                        "adaptive",
-                        "inherit"
-                    ],
-                    "enumDescriptions": [
-                        "Use 2 spaces for unordered list and 3 for the ordered",
-                        "Use the configured tab size of the current document (see vscode status bar)"
-                    ],
-                    "default": "adaptive",
-                    "description": "Whether to use different indentation sizes on different contexts",
-                    "scope": "resource"
-                },
-                "markdown.extension.preview.autoShowPreviewToSide": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "%config.preview.autoShowPreviewToSide.description%"
-                },
-                "markdown.extension.orderedList.marker": {
-                    "type": "string",
-                    "default": "ordered",
-                    "description": "%config.orderedList.marker.description%",
-                    "enum": [
-                        "one",
-                        "ordered"
-                    ]
-                },
-                "markdown.extension.orderedList.autoRenumber": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "%config.orderedList.autoRenumber.description%"
-                },
-                "markdown.extension.italic.indicator": {
-                    "type": "string",
-                    "default": "*",
-                    "description": "%config.italic.indicator.description%",
-                    "enum": [
-                        "*",
-                        "_"
-                    ]
-                },
-                "markdown.extension.showExplorer": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "%config.showExplorer.description%"
-                },
-                "markdown.extension.tableFormatter.enabled": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "%config.tableFormatter.enabled.description%"
-                },
-                "markdown.extension.tableFormatter.normalizeIndentation": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "%config.tableFormatter.normalizeIndentation.description%"
-                },
-                "markdown.extension.print.absoluteImgPath": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "%config.print.absoluteImgPath.description%",
-                    "scope": "resource"
-                },
-                "markdown.extension.print.imgToBase64": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "%config.print.imgToBase64.description%",
-                    "scope": "resource"
-                },
-                "markdown.extension.syntax.decorations": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "%config.syntax.decorations.description%"
-                },
-                "markdown.extension.syntax.plainTheme": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "%config.syntax.plainTheme.description%"
-                }
-            }
+    "configuration": {
+      "type": "object",
+      "title": "%config.title%",
+      "properties": {
+        "markdown.extension.toc.levels": {
+          "type": "string",
+          "default": "1..6",
+          "description": "%config.toc.levels.description%"
         },
-        "markdown.markdownItPlugins": true,
-        "markdown.previewStyles": [
-            "./media/checkbox.css",
-            "./node_modules/katex/dist/katex.min.css"
-        ],
-        "grammars": [
-            {
-                "scopeName": "markdown.math_display",
-                "path": "./syntaxes/math_display.markdown.tmLanguage.json",
-                "injectTo": [
-                    "text.html.markdown"
-                ]
-            },
-            {
-                "scopeName": "markdown.math_inline",
-                "path": "./syntaxes/math_inline.markdown.tmLanguage.json",
-                "injectTo": [
-                    "text.html.markdown"
-                ]
-            },
-            {
-                "scopeName": "text.katex",
-                "path": "./syntaxes/katex.tmLanguage.json"
-            }
+        "markdown.extension.toc.orderedList": {
+          "type": "boolean",
+          "default": false,
+          "description": "%config.toc.orderedList.description%"
+        },
+        "markdown.extension.toc.marker": {
+          "type": "string",
+          "default": "·"
+        },
+        "markdown.extension.toc.markerSkipLast": {
+          "type": "boolean",
+          "default": true
+        },
+        "markdown.extension.toc.template": {
+          "type": "string",
+          "default": "[{name}]({link}) {marker}"
+        },
+        "markdown.extension.toc.unorderedList.marker": {
+          "type": "string",
+          "default": "-",
+          "description": "%config.toc.unorderedList.marker.description%",
+          "enum": [
+            "-",
+            "*",
+            "+"
+          ]
+        },
+        "markdown.extension.toc.plaintext": {
+          "type": "boolean",
+          "default": false,
+          "description": "%config.toc.plaintext.description%"
+        },
+        "markdown.extension.toc.updateOnSave": {
+          "type": "boolean",
+          "default": true,
+          "description": "%config.toc.updateOnSave.description%"
+        },
+        "markdown.extension.toc.githubCompatibility": {
+          "type": "boolean",
+          "default": false,
+          "description": "%config.toc.githubCompatibility.description%"
+        },
+        "markdown.extension.list.indentationSize": {
+          "type": "string",
+          "enum": [
+            "adaptive",
+            "inherit"
+          ],
+          "enumDescriptions": [
+            "Use 2 spaces for unordered list and 3 for the ordered",
+            "Use the configured tab size of the current document (see vscode status bar)"
+          ],
+          "default": "adaptive",
+          "description": "Whether to use different indentation sizes on different contexts",
+          "scope": "resource"
+        },
+        "markdown.extension.preview.autoShowPreviewToSide": {
+          "type": "boolean",
+          "default": false,
+          "description": "%config.preview.autoShowPreviewToSide.description%"
+        },
+        "markdown.extension.orderedList.marker": {
+          "type": "string",
+          "default": "ordered",
+          "description": "%config.orderedList.marker.description%",
+          "enum": [
+            "one",
+            "ordered"
+          ]
+        },
+        "markdown.extension.orderedList.autoRenumber": {
+          "type": "boolean",
+          "default": true,
+          "description": "%config.orderedList.autoRenumber.description%"
+        },
+        "markdown.extension.italic.indicator": {
+          "type": "string",
+          "default": "*",
+          "description": "%config.italic.indicator.description%",
+          "enum": [
+            "*",
+            "_"
+          ]
+        },
+        "markdown.extension.showExplorer": {
+          "type": "boolean",
+          "default": false,
+          "description": "%config.showExplorer.description%"
+        },
+        "markdown.extension.tableFormatter.enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "%config.tableFormatter.enabled.description%"
+        },
+        "markdown.extension.tableFormatter.normalizeIndentation": {
+          "type": "boolean",
+          "default": false,
+          "description": "%config.tableFormatter.normalizeIndentation.description%"
+        },
+        "markdown.extension.print.absoluteImgPath": {
+          "type": "boolean",
+          "default": true,
+          "description": "%config.print.absoluteImgPath.description%",
+          "scope": "resource"
+        },
+        "markdown.extension.print.imgToBase64": {
+          "type": "boolean",
+          "default": false,
+          "description": "%config.print.imgToBase64.description%",
+          "scope": "resource"
+        },
+        "markdown.extension.syntax.decorations": {
+          "type": "boolean",
+          "default": true,
+          "description": "%config.syntax.decorations.description%"
+        },
+        "markdown.extension.syntax.plainTheme": {
+          "type": "boolean",
+          "default": false,
+          "description": "%config.syntax.plainTheme.description%"
+        }
+      }
+    },
+    "markdown.markdownItPlugins": true,
+    "markdown.previewStyles": [
+      "./media/checkbox.css",
+      "./node_modules/katex/dist/katex.min.css"
+    ],
+    "grammars": [
+      {
+        "scopeName": "markdown.math_display",
+        "path": "./syntaxes/math_display.markdown.tmLanguage.json",
+        "injectTo": [
+          "text.html.markdown"
         ]
-    },
-    "scripts": {
-        "vscode:prepublish": "webpack --mode production",
-        "compile": "webpack --mode none",
-        "watch": "webpack --mode none --watch",
-        "postinstall": "node ./node_modules/vscode/bin/install",
-        "test": "tsc -p ./ && node ./node_modules/vscode/bin/test",
-        "test-compile": "tsc -p ./"
-    },
-    "dependencies": {
-        "@neilsustc/markdown-it-katex": "^0.3.0",
-        "highlight.js": "^9.15.6",
-        "image-size": "^0.7.2",
-        "markdown-it": "^8.4.2",
-        "markdown-it-task-lists": "^2.1.1",
-        "string-similarity": "^3.0.0"
-    },
-    "devDependencies": {
-        "@types/highlight.js": "^9.12.3",
-        "@types/image-size": "^0.7.0",
-        "@types/markdown-it": "^0.0.7",
-        "@types/mocha": "^5.2.6",
-        "@types/node": "^11.11.3",
-        "mocha": "^6.0.2",
-        "ts-loader": "^5.3.3",
-        "typescript": "^3.3.3333",
-        "vscode": "^1.1.30",
-        "webpack": "^4.29.6",
-        "webpack-cli": "^3.2.3"
-    }
+      },
+      {
+        "scopeName": "markdown.math_inline",
+        "path": "./syntaxes/math_inline.markdown.tmLanguage.json",
+        "injectTo": [
+          "text.html.markdown"
+        ]
+      },
+      {
+        "scopeName": "text.katex",
+        "path": "./syntaxes/katex.tmLanguage.json"
+      }
+    ]
+  },
+  "displayName": "%ext.displayName%",
+  "icon": "images/Markdown-mark.png",
+  "publisher": "yzhang"
 }

--- a/package.json
+++ b/package.json
@@ -1,355 +1,367 @@
 {
-  "name": "markdown-all-in-one",
-  "displayName": "%ext.displayName%",
-  "description": "%ext.description%",
-  "icon": "images/Markdown-mark.png",
-  "version": "2.2.0",
-  "publisher": "yzhang",
-  "engines": {
-      "vscode": "^1.30.2"
-  },
-  "categories": [
-      "Other"
-  ],
-  "keywords": [
-      "markdown"
-  ],
-  "bugs": {
-      "url": "https://github.com/yzhang-gh/vscode-markdown/issues"
-  },
-  "repository": {
-      "type": "git",
-      "url": "https://github.com/yzhang-gh/vscode-markdown"
-  },
-  "license": "MIT",
-  "activationEvents": [
-      "onLanguage:markdown",
-      "workspaceContains:README.md"
-  ],
-  "main": "./dist/extension",
-  "contributes": {
-      "commands": [
-          {
-              "command": "markdown.extension.toc.create",
-              "title": "%command.toc.create.title%"
-          },
-          {
-              "command": "markdown.extension.toc.update",
-              "title": "%command.toc.update.title%"
-          },
-          {
-              "command": "markdown.extension.printToHtml",
-              "title": "%command.printToHtml.title%"
-          },
-          {
-              "command": "markdown.extension.editing.toggleCodeSpan",
-              "title": "%command.editing.toggleCodeSpan.title%"
-          },
-          {
-              "command": "markdown.extension.editing.toggleMath",
-              "title": "%command.editing.toggleMath.title%"
-          },
-          {
-              "command": "markdown.extension.editing.toggleUnorderedList",
-              "title": "%command.editing.toggleUnorderedList.title%"
-          }
-      ],
-      "keybindings": [
-          {
-              "command": "markdown.extension.editing.toggleBold",
-              "key": "ctrl+b",
-              "mac": "cmd+b",
-              "when": "editorTextFocus && !editorReadonly && editorLangId == markdown"
-          },
-          {
-              "command": "markdown.extension.editing.toggleItalic",
-              "key": "ctrl+i",
-              "mac": "cmd+i",
-              "when": "editorTextFocus && !editorReadonly && editorLangId == markdown"
-          },
-          {
-              "command": "markdown.extension.editing.toggleStrikethrough",
-              "key": "alt+s",
-              "when": "editorTextFocus && !editorReadonly && editorLangId == markdown && !isMac"
-          },
-          {
-              "command": "markdown.extension.editing.toggleHeadingUp",
-              "key": "ctrl+shift+]",
-              "mac": "ctrl+shift+]",
-              "when": "editorTextFocus && !editorReadonly && editorLangId == markdown"
-          },
-          {
-              "command": "markdown.extension.editing.toggleHeadingDown",
-              "key": "ctrl+shift+[",
-              "mac": "ctrl+shift+[",
-              "when": "editorTextFocus && !editorReadonly && editorLangId == markdown"
-          },
-          {
-              "command": "markdown.extension.editing.toggleMath",
-              "key": "ctrl+m",
-              "mac": "cmd+m",
-              "when": "editorTextFocus && !editorReadonly && editorLangId == markdown"
-          },
-          {
-              "command": "markdown.extension.onEnterKey",
-              "key": "enter",
-              "when": "editorTextFocus && !editorReadonly && editorLangId == markdown && !suggestWidgetVisible && vim.mode != 'Normal' && vim.mode != 'Visual' && vim.mode != 'VisualBlock' && vim.mode != 'VisualLine' && vim.mode != 'SearchInProgressMode' && vim.mode != 'CommandlineInProgress' && vim.mode != 'Replace' && vim.mode != 'EasyMotionMode' && vim.mode != 'EasyMotionInputMode' && vim.mode != 'SurroundInputMode'"
-          },
-          {
-              "command": "markdown.extension.onCtrlEnterKey",
-              "key": "ctrl+enter",
-              "mac": "cmd+enter",
-              "when": "editorTextFocus && !editorReadonly && editorLangId == markdown && !suggestWidgetVisible"
-          },
-          {
-              "command": "markdown.extension.onShiftEnterKey",
-              "key": "shift+enter",
-              "when": "editorTextFocus && !editorReadonly && editorLangId == markdown && !suggestWidgetVisible"
-          },
-          {
-              "command": "markdown.extension.onTabKey",
-              "key": "tab",
-              "when": "editorTextFocus && !editorReadonly && editorLangId == markdown && !suggestWidgetVisible && !editorTabMovesFocus && !inSnippetMode && !hasSnippetCompletions && !hasOtherSuggestions"
-          },
-          {
-              "command": "markdown.extension.onShiftTabKey",
-              "key": "shift+tab",
-              "when": "editorTextFocus && !editorReadonly && editorLangId == markdown && !suggestWidgetVisible && !editorTabMovesFocus && !inSnippetMode && !hasSnippetCompletions && !hasOtherSuggestions"
-          },
-          {
-              "command": "markdown.extension.onBackspaceKey",
-              "key": "backspace",
-              "when": "editorTextFocus && !editorReadonly && editorLangId == markdown && !suggestWidgetVisible && vim.mode != 'Normal' && vim.mode != 'Visual' && vim.mode != 'VisualBlock' && vim.mode != 'VisualLine' && vim.mode != 'SearchInProgressMode' && vim.mode != 'CommandlineInProgress' && vim.mode != 'Replace' && vim.mode != 'EasyMotionMode' && vim.mode != 'EasyMotionInputMode' && vim.mode != 'SurroundInputMode'"
-          },
-          {
-              "command": "markdown.extension.onMoveLineUp",
-              "key": "alt+up",
-              "when": "editorTextFocus && !editorReadonly && editorLangId == markdown && !suggestWidgetVisible"
-          },
-          {
-              "command": "markdown.extension.onMoveLineDown",
-              "key": "alt+down",
-              "when": "editorTextFocus && !editorReadonly && editorLangId == markdown && !suggestWidgetVisible"
-          },
-          {
-              "command": "markdown.extension.onCopyLineUp",
-              "key": "shift+alt+up",
-              "when": "editorTextFocus && !editorReadonly && editorLangId == markdown && !suggestWidgetVisible"
-          },
-          {
-              "command": "markdown.extension.onCopyLineDown",
-              "key": "shift+alt+down",
-              "when": "editorTextFocus && !editorReadonly && editorLangId == markdown && !suggestWidgetVisible"
-          },
-          {
-              "command": "markdown.extension.onIndentLines",
-              "key": "ctrl+]",
-              "mac": "cmd+]",
-              "when": "editorTextFocus && editorLangId == markdown && !suggestWidgetVisible"
-          },
-          {
-              "command": "markdown.extension.onOutdentLines",
-              "key": "ctrl+[",
-              "mac": "cmd+[",
-              "when": "editorTextFocus && editorLangId == markdown && !suggestWidgetVisible"
-          },
-          {
-              "command": "markdown.extension.checkTaskList",
-              "key": "alt+c",
-              "when": "editorTextFocus && editorLangId == markdown"
-          },
-          {
-              "command": "markdown.extension.togglePreview",
-              "key": "ctrl+shift+v",
-              "mac": "cmd+shift+v",
-              "when": "!terminalFocus"
-          },
-          {
-              "command": "markdown.extension.togglePreviewToSide",
-              "key": "ctrl+k v",
-              "mac": "cmd+k v",
-              "when": "!terminalFocus"
-          },
-          {
-              "command": "markdown.extension.editing.paste",
-              "key": "ctrl+v",
-              "mac": "cmd+v",
-              "when": "editorTextFocus && editorLangId == markdown && editorHasSelection"
-          }
-      ],
-      "configuration": {
-          "type": "object",
-          "title": "%config.title%",
-          "properties": {
-              "markdown.extension.toc.levels": {
+    "name": "markdown-all-in-one",
+    "displayName": "%ext.displayName%",
+    "description": "%ext.description%",
+    "icon": "images/Markdown-mark.png",
+    "version": "2.2.0",
+    "publisher": "yzhang",
+    "engines": {
+        "vscode": "^1.30.2"
+    },
+    "categories": [
+        "Other"
+    ],
+    "keywords": [
+        "markdown"
+    ],
+    "bugs": {
+        "url": "https://github.com/yzhang-gh/vscode-markdown/issues"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/yzhang-gh/vscode-markdown"
+    },
+    "license": "MIT",
+    "activationEvents": [
+        "onLanguage:markdown",
+        "workspaceContains:README.md"
+    ],
+    "main": "./dist/extension",
+    "contributes": {
+        "commands": [
+            {
+                "command": "markdown.extension.toc.create",
+                "title": "%command.toc.create.title%"
+            },
+            {
+                "command": "markdown.extension.toc.update",
+                "title": "%command.toc.update.title%"
+            },
+            {
+                "command": "markdown.extension.printToHtml",
+                "title": "%command.printToHtml.title%"
+            },
+            {
+                "command": "markdown.extension.editing.toggleCodeSpan",
+                "title": "%command.editing.toggleCodeSpan.title%"
+            },
+            {
+                "command": "markdown.extension.editing.toggleMath",
+                "title": "%command.editing.toggleMath.title%"
+            },
+            {
+                "command": "markdown.extension.editing.toggleUnorderedList",
+                "title": "%command.editing.toggleUnorderedList.title%"
+            }
+        ],
+        "keybindings": [
+            {
+                "command": "markdown.extension.editing.toggleBold",
+                "key": "ctrl+b",
+                "mac": "cmd+b",
+                "when": "editorTextFocus && !editorReadonly && editorLangId == markdown"
+            },
+            {
+                "command": "markdown.extension.editing.toggleItalic",
+                "key": "ctrl+i",
+                "mac": "cmd+i",
+                "when": "editorTextFocus && !editorReadonly && editorLangId == markdown"
+            },
+            {
+                "command": "markdown.extension.editing.toggleStrikethrough",
+                "key": "alt+s",
+                "when": "editorTextFocus && !editorReadonly && editorLangId == markdown && !isMac"
+            },
+            {
+                "command": "markdown.extension.editing.toggleHeadingUp",
+                "key": "ctrl+shift+]",
+                "mac": "ctrl+shift+]",
+                "when": "editorTextFocus && !editorReadonly && editorLangId == markdown"
+            },
+            {
+                "command": "markdown.extension.editing.toggleHeadingDown",
+                "key": "ctrl+shift+[",
+                "mac": "ctrl+shift+[",
+                "when": "editorTextFocus && !editorReadonly && editorLangId == markdown"
+            },
+            {
+                "command": "markdown.extension.editing.toggleMath",
+                "key": "ctrl+m",
+                "mac": "cmd+m",
+                "when": "editorTextFocus && !editorReadonly && editorLangId == markdown"
+            },
+            {
+                "command": "markdown.extension.onEnterKey",
+                "key": "enter",
+                "when": "editorTextFocus && !editorReadonly && editorLangId == markdown && !suggestWidgetVisible && vim.mode != 'Normal' && vim.mode != 'Visual' && vim.mode != 'VisualBlock' && vim.mode != 'VisualLine' && vim.mode != 'SearchInProgressMode' && vim.mode != 'CommandlineInProgress' && vim.mode != 'Replace' && vim.mode != 'EasyMotionMode' && vim.mode != 'EasyMotionInputMode' && vim.mode != 'SurroundInputMode'"
+            },
+            {
+                "command": "markdown.extension.onCtrlEnterKey",
+                "key": "ctrl+enter",
+                "mac": "cmd+enter",
+                "when": "editorTextFocus && !editorReadonly && editorLangId == markdown && !suggestWidgetVisible"
+            },
+            {
+                "command": "markdown.extension.onShiftEnterKey",
+                "key": "shift+enter",
+                "when": "editorTextFocus && !editorReadonly && editorLangId == markdown && !suggestWidgetVisible"
+            },
+            {
+                "command": "markdown.extension.onTabKey",
+                "key": "tab",
+                "when": "editorTextFocus && !editorReadonly && editorLangId == markdown && !suggestWidgetVisible && !editorTabMovesFocus && !inSnippetMode && !hasSnippetCompletions && !hasOtherSuggestions"
+            },
+            {
+                "command": "markdown.extension.onShiftTabKey",
+                "key": "shift+tab",
+                "when": "editorTextFocus && !editorReadonly && editorLangId == markdown && !suggestWidgetVisible && !editorTabMovesFocus && !inSnippetMode && !hasSnippetCompletions && !hasOtherSuggestions"
+            },
+            {
+                "command": "markdown.extension.onBackspaceKey",
+                "key": "backspace",
+                "when": "editorTextFocus && !editorReadonly && editorLangId == markdown && !suggestWidgetVisible && vim.mode != 'Normal' && vim.mode != 'Visual' && vim.mode != 'VisualBlock' && vim.mode != 'VisualLine' && vim.mode != 'SearchInProgressMode' && vim.mode != 'CommandlineInProgress' && vim.mode != 'Replace' && vim.mode != 'EasyMotionMode' && vim.mode != 'EasyMotionInputMode' && vim.mode != 'SurroundInputMode'"
+            },
+            {
+                "command": "markdown.extension.onMoveLineUp",
+                "key": "alt+up",
+                "when": "editorTextFocus && !editorReadonly && editorLangId == markdown && !suggestWidgetVisible"
+            },
+            {
+                "command": "markdown.extension.onMoveLineDown",
+                "key": "alt+down",
+                "when": "editorTextFocus && !editorReadonly && editorLangId == markdown && !suggestWidgetVisible"
+            },
+            {
+                "command": "markdown.extension.onCopyLineUp",
+                "key": "shift+alt+up",
+                "when": "editorTextFocus && !editorReadonly && editorLangId == markdown && !suggestWidgetVisible"
+            },
+            {
+                "command": "markdown.extension.onCopyLineDown",
+                "key": "shift+alt+down",
+                "when": "editorTextFocus && !editorReadonly && editorLangId == markdown && !suggestWidgetVisible"
+            },
+            {
+                "command": "markdown.extension.onIndentLines",
+                "key": "ctrl+]",
+                "mac": "cmd+]",
+                "when": "editorTextFocus && editorLangId == markdown && !suggestWidgetVisible"
+            },
+            {
+                "command": "markdown.extension.onOutdentLines",
+                "key": "ctrl+[",
+                "mac": "cmd+[",
+                "when": "editorTextFocus && editorLangId == markdown && !suggestWidgetVisible"
+            },
+            {
+                "command": "markdown.extension.checkTaskList",
+                "key": "alt+c",
+                "when": "editorTextFocus && editorLangId == markdown"
+            },
+            {
+                "command": "markdown.extension.togglePreview",
+                "key": "ctrl+shift+v",
+                "mac": "cmd+shift+v",
+                "when": "!terminalFocus"
+            },
+            {
+                "command": "markdown.extension.togglePreviewToSide",
+                "key": "ctrl+k v",
+                "mac": "cmd+k v",
+                "when": "!terminalFocus"
+            },
+            {
+                "command": "markdown.extension.editing.paste",
+                "key": "ctrl+v",
+                "mac": "cmd+v",
+                "when": "editorTextFocus && editorLangId == markdown && editorHasSelection"
+            }
+        ],
+        "configuration": {
+            "type": "object",
+            "title": "%config.title%",
+            "properties": {
+                "markdown.extension.toc.marker": {
                   "type": "string",
-                  "default": "1..6",
-                  "description": "%config.toc.levels.description%"
-              },
-              "markdown.extension.toc.orderedList": {
+                  "default": "·"
+                },
+                "markdown.extension.toc.markerSkipLast": {
                   "type": "boolean",
-                  "default": false,
-                  "description": "%config.toc.orderedList.description%"
-              },
-              "markdown.extension.toc.unorderedList.marker": {
+                  "default": true
+                },
+                "markdown.extension.toc.template": {
                   "type": "string",
-                  "default": "-",
-                  "description": "%config.toc.unorderedList.marker.description%",
-                  "enum": [
-                      "-",
-                      "*",
-                      "+"
-                  ]
-              },
-              "markdown.extension.toc.plaintext": {
-                  "type": "boolean",
-                  "default": false,
-                  "description": "%config.toc.plaintext.description%"
-              },
-              "markdown.extension.toc.updateOnSave": {
-                  "type": "boolean",
-                  "default": true,
-                  "description": "%config.toc.updateOnSave.description%"
-              },
-              "markdown.extension.toc.githubCompatibility": {
-                  "type": "boolean",
-                  "default": false,
-                  "description": "%config.toc.githubCompatibility.description%"
-              },
-              "markdown.extension.list.indentationSize": {
-                  "type": "string",
-                  "enum": [
-                      "adaptive",
-                      "inherit"
-                  ],
-                  "enumDescriptions": [
-                      "Use 2 spaces for unordered list and 3 for the ordered",
-                      "Use the configured tab size of the current document (see vscode status bar)"
-                  ],
-                  "default": "adaptive",
-                  "description": "Whether to use different indentation sizes on different contexts",
-                  "scope": "resource"
-              },
-              "markdown.extension.preview.autoShowPreviewToSide": {
-                  "type": "boolean",
-                  "default": false,
-                  "description": "%config.preview.autoShowPreviewToSide.description%"
-              },
-              "markdown.extension.orderedList.marker": {
-                  "type": "string",
-                  "default": "ordered",
-                  "description": "%config.orderedList.marker.description%",
-                  "enum": [
-                      "one",
-                      "ordered"
-                  ]
-              },
-              "markdown.extension.orderedList.autoRenumber": {
-                  "type": "boolean",
-                  "default": true,
-                  "description": "%config.orderedList.autoRenumber.description%"
-              },
-              "markdown.extension.italic.indicator": {
-                  "type": "string",
-                  "default": "*",
-                  "description": "%config.italic.indicator.description%",
-                  "enum": [
-                      "*",
-                      "_"
-                  ]
-              },
-              "markdown.extension.showExplorer": {
-                  "type": "boolean",
-                  "default": false,
-                  "description": "%config.showExplorer.description%"
-              },
-              "markdown.extension.tableFormatter.enabled": {
-                  "type": "boolean",
-                  "default": true,
-                  "description": "%config.tableFormatter.enabled.description%"
-              },
-              "markdown.extension.tableFormatter.normalizeIndentation": {
-                  "type": "boolean",
-                  "default": false,
-                  "description": "%config.tableFormatter.normalizeIndentation.description%"
-              },
-              "markdown.extension.print.absoluteImgPath": {
-                  "type": "boolean",
-                  "default": true,
-                  "description": "%config.print.absoluteImgPath.description%",
-                  "scope": "resource"
-              },
-              "markdown.extension.print.imgToBase64": {
-                  "type": "boolean",
-                  "default": false,
-                  "description": "%config.print.imgToBase64.description%",
-                  "scope": "resource"
-              },
-              "markdown.extension.syntax.decorations": {
-                  "type": "boolean",
-                  "default": true,
-                  "description": "%config.syntax.decorations.description%"
-              },
-              "markdown.extension.syntax.plainTheme": {
-                  "type": "boolean",
-                  "default": false,
-                  "description": "%config.syntax.plainTheme.description%"
-              }
-          }
-      },
-      "markdown.markdownItPlugins": true,
-      "markdown.previewStyles": [
-          "./media/checkbox.css",
-          "./node_modules/katex/dist/katex.min.css"
-      ],
-      "grammars": [
-          {
-              "scopeName": "markdown.math_display",
-              "path": "./syntaxes/math_display.markdown.tmLanguage.json",
-              "injectTo": [
-                  "text.html.markdown"
-              ]
-          },
-          {
-              "scopeName": "markdown.math_inline",
-              "path": "./syntaxes/math_inline.markdown.tmLanguage.json",
-              "injectTo": [
-                  "text.html.markdown"
-              ]
-          },
-          {
-              "scopeName": "text.katex",
-              "path": "./syntaxes/katex.tmLanguage.json"
-          }
-      ]
-  },
-  "scripts": {
-      "vscode:prepublish": "webpack --mode production",
-      "compile": "webpack --mode none",
-      "watch": "webpack --mode none --watch",
-      "postinstall": "node ./node_modules/vscode/bin/install",
-      "test": "tsc -p ./ && node ./node_modules/vscode/bin/test",
-      "test-compile": "tsc -p ./"
-  },
-  "dependencies": {
-      "@neilsustc/markdown-it-katex": "^0.3.0",
-      "highlight.js": "^9.15.6",
-      "image-size": "^0.7.2",
-      "markdown-it": "^8.4.2",
-      "markdown-it-task-lists": "^2.1.1",
-      "string-similarity": "^3.0.0"
-  },
-  "devDependencies": {
-      "@types/highlight.js": "^9.12.3",
-      "@types/image-size": "^0.7.0",
-      "@types/markdown-it": "^0.0.7",
-      "@types/mocha": "^5.2.6",
-      "@types/node": "^11.11.3",
-      "mocha": "^6.0.2",
-      "ts-loader": "^5.3.3",
-      "typescript": "^3.3.3333",
-      "vscode": "^1.1.30",
-      "webpack": "^4.29.6",
-      "webpack-cli": "^3.2.3"
-  }
+                  "default": "{marker} [{name}]({link})"
+                },
+                "markdown.extension.toc.levels": {
+                    "type": "string",
+                    "default": "1..6",
+                    "description": "%config.toc.levels.description%"
+                },
+                "markdown.extension.toc.orderedList": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "%config.toc.orderedList.description%"
+                },
+                "markdown.extension.toc.unorderedList.marker": {
+                    "type": "string",
+                    "default": "-",
+                    "description": "%config.toc.unorderedList.marker.description%",
+                    "enum": [
+                        "-",
+                        "*",
+                        "+"
+                    ]
+                },
+                "markdown.extension.toc.plaintext": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "%config.toc.plaintext.description%"
+                },
+                "markdown.extension.toc.updateOnSave": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "%config.toc.updateOnSave.description%"
+                },
+                "markdown.extension.toc.githubCompatibility": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "%config.toc.githubCompatibility.description%"
+                },
+                "markdown.extension.list.indentationSize": {
+                    "type": "string",
+                    "enum": [
+                        "adaptive",
+                        "inherit"
+                    ],
+                    "enumDescriptions": [
+                        "Use 2 spaces for unordered list and 3 for the ordered",
+                        "Use the configured tab size of the current document (see vscode status bar)"
+                    ],
+                    "default": "adaptive",
+                    "description": "Whether to use different indentation sizes on different contexts",
+                    "scope": "resource"
+                },
+                "markdown.extension.preview.autoShowPreviewToSide": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "%config.preview.autoShowPreviewToSide.description%"
+                },
+                "markdown.extension.orderedList.marker": {
+                    "type": "string",
+                    "default": "ordered",
+                    "description": "%config.orderedList.marker.description%",
+                    "enum": [
+                        "one",
+                        "ordered"
+                    ]
+                },
+                "markdown.extension.orderedList.autoRenumber": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "%config.orderedList.autoRenumber.description%"
+                },
+                "markdown.extension.italic.indicator": {
+                    "type": "string",
+                    "default": "*",
+                    "description": "%config.italic.indicator.description%",
+                    "enum": [
+                        "*",
+                        "_"
+                    ]
+                },
+                "markdown.extension.showExplorer": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "%config.showExplorer.description%"
+                },
+                "markdown.extension.tableFormatter.enabled": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "%config.tableFormatter.enabled.description%"
+                },
+                "markdown.extension.tableFormatter.normalizeIndentation": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "%config.tableFormatter.normalizeIndentation.description%"
+                },
+                "markdown.extension.print.absoluteImgPath": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "%config.print.absoluteImgPath.description%",
+                    "scope": "resource"
+                },
+                "markdown.extension.print.imgToBase64": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "%config.print.imgToBase64.description%",
+                    "scope": "resource"
+                },
+                "markdown.extension.syntax.decorations": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "%config.syntax.decorations.description%"
+                },
+                "markdown.extension.syntax.plainTheme": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "%config.syntax.plainTheme.description%"
+                }
+            }
+        },
+        "markdown.markdownItPlugins": true,
+        "markdown.previewStyles": [
+            "./media/checkbox.css",
+            "./node_modules/katex/dist/katex.min.css"
+        ],
+        "grammars": [
+            {
+                "scopeName": "markdown.math_display",
+                "path": "./syntaxes/math_display.markdown.tmLanguage.json",
+                "injectTo": [
+                    "text.html.markdown"
+                ]
+            },
+            {
+                "scopeName": "markdown.math_inline",
+                "path": "./syntaxes/math_inline.markdown.tmLanguage.json",
+                "injectTo": [
+                    "text.html.markdown"
+                ]
+            },
+            {
+                "scopeName": "text.katex",
+                "path": "./syntaxes/katex.tmLanguage.json"
+            }
+        ]
+    },
+    "scripts": {
+        "vscode:prepublish": "webpack --mode production",
+        "compile": "webpack --mode none",
+        "watch": "webpack --mode none --watch",
+        "postinstall": "node ./node_modules/vscode/bin/install",
+        "test": "tsc -p ./ && node ./node_modules/vscode/bin/test",
+        "test-compile": "tsc -p ./"
+    },
+    "dependencies": {
+        "@neilsustc/markdown-it-katex": "^0.3.0",
+        "highlight.js": "^9.15.6",
+        "image-size": "^0.7.2",
+        "markdown-it": "^8.4.2",
+        "markdown-it-task-lists": "^2.1.1",
+        "string-similarity": "^3.0.0"
+    },
+    "devDependencies": {
+        "@types/highlight.js": "^9.12.3",
+        "@types/image-size": "^0.7.0",
+        "@types/markdown-it": "^0.0.7",
+        "@types/mocha": "^5.2.6",
+        "@types/node": "^11.11.3",
+        "mocha": "^6.0.2",
+        "ts-loader": "^5.3.3",
+        "typescript": "^3.3.3333",
+        "vscode": "^1.1.30",
+        "webpack": "^4.29.6",
+        "webpack-cli": "^3.2.3"
+    }
 }

--- a/src/toc.ts
+++ b/src/toc.ts
@@ -95,7 +95,7 @@ async function generateTocText(): Promise<string> {
               template = tocConfig.template
                 .replace("{marker}", (orderedListMarkerIsOne ? "1" : ++order[relativeLvl]) + ".")
                 .replace("{name}", entryText)
-                .replace("{link}", slugify(anchorText))
+                .replace("{link}", "#" + slugify(anchorText))
             } else {
               template = tocConfig.template
                 .replace("{marker}", tocConfig.marker)

--- a/src/toc.ts
+++ b/src/toc.ts
@@ -1,120 +1,107 @@
-'use strict';
+"use strict"
 
-import * as vscode from 'vscode';
-import { extractText, isMdEditor, mdDocSelector, slugify } from './util';
-import * as stringSimilarity from 'string-similarity';
+import * as vscode from "vscode"
+import { extractText, isMdEditor, mdDocSelector, slugify } from "./util"
+import * as stringSimilarity from "string-similarity"
 
 /**
  * Workspace config
  */
-const docConfig = { tab: '  ', eol: '\r\n' };
+const docConfig = { tab: "  ", eol: "\r\n" }
 const tocConfig = {
-  startDepth: 1,
-  endDepth: 6,
-  listMarker: '-',
-  orderedList: false,
-  updateOnSave: false,
-  plaintext: false,
-  tabSize: 2,
-  marker: "-",
-  template: "",
-  markerSkipLast: false,
-};
+    startDepth: 1,
+    endDepth: 6,
+    listMarker: "-",
+    orderedList: false,
+    updateOnSave: false,
+    plaintext: false,
+    tabSize: 2,
+}
 
 export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(
-        vscode.commands.registerCommand('markdown.extension.toc.create', createToc),
-        vscode.commands.registerCommand('markdown.extension.toc.update', updateToc),
+        vscode.commands.registerCommand("markdown.extension.toc.create", createToc),
+        vscode.commands.registerCommand("markdown.extension.toc.update", updateToc),
         vscode.workspace.onWillSaveTextDocument(onWillSave),
         vscode.languages.registerCodeLensProvider(mdDocSelector, new TocCodeLensProvider())
-    );
+    )
 }
 
 async function createToc() {
-    let editor = vscode.window.activeTextEditor;
-    let toc = await generateTocText();
-    await editor.edit(function (editBuilder) {
-        editBuilder.delete(editor.selection);
-        editBuilder.insert(editor.selection.active, toc);
-    });
+    let editor = vscode.window.activeTextEditor
+    let toc = await generateTocText()
+    await editor.edit(function(editBuilder) {
+        editBuilder.delete(editor.selection)
+        editBuilder.insert(editor.selection.active, toc)
+    })
 }
 
 async function updateToc() {
-    let editor = vscode.window.activeTextEditor;
-    let doc = editor.document;
-    let tocRanges = await detectTocRanges(doc);
-    let newToc = await generateTocText();
+    let editor = vscode.window.activeTextEditor
+    let doc = editor.document
+    let tocRanges = await detectTocRanges(doc)
+    let newToc = await generateTocText()
     await editor.edit(editBuilder => {
         for (let tocRange of tocRanges) {
             if (tocRange !== null) {
-                let oldToc = getText(tocRange).replace(/\r?\n|\r/g, docConfig.eol);
+                let oldToc = getText(tocRange).replace(/\r?\n|\r/g, docConfig.eol)
                 if (oldToc !== newToc) {
-                    let unchangedLength = commonPrefixLength(oldToc, newToc);
-                    let newStart = doc.positionAt(doc.offsetAt(tocRange.start) + unchangedLength);
-                    let replaceRange = tocRange.with(newStart);
+                    let unchangedLength = commonPrefixLength(oldToc, newToc)
+                    let newStart = doc.positionAt(doc.offsetAt(tocRange.start) + unchangedLength)
+                    let replaceRange = tocRange.with(newStart)
                     if (replaceRange.isEmpty) {
-                        editBuilder.insert(replaceRange.start, newToc.substring(unchangedLength));
+                        editBuilder.insert(replaceRange.start, newToc.substring(unchangedLength))
                     } else {
-                        editBuilder.replace(replaceRange, newToc.substring(unchangedLength));
+                        editBuilder.replace(replaceRange, newToc.substring(unchangedLength))
                     }
                 }
             }
         }
-    });
+    })
 }
 
 async function generateTocText(): Promise<string> {
-    loadTocConfig();
-    const orderedListMarkerIsOne: boolean = vscode.workspace.getConfiguration('markdown.extension.orderedList').get<string>('marker') === 'one';
+    loadTocConfig()
+    const orderedListMarkerIsOne: boolean =
+        vscode.workspace.getConfiguration("markdown.extension.orderedList").get<string>("marker") === "one"
 
-    let toc = [];
-    let tocEntries = buildToc();
-    if (tocEntries === null || tocEntries === undefined || tocEntries.length < 1) return '';
+    let toc = []
+    let tocEntries = buildToc()
+    if (tocEntries === null || tocEntries === undefined || tocEntries.length < 1) return ""
 
-    let startDepth = Math.max(tocConfig.startDepth, Math.min.apply(null, tocEntries.map(h => h.level)));
-    let order = new Array(tocConfig.endDepth - startDepth + 1).fill(0); // Used for ordered list
+    let startDepth = Math.max(tocConfig.startDepth, Math.min.apply(null, tocEntries.map(h => h.level)))
+    let order = new Array(tocConfig.endDepth - startDepth + 1).fill(0) // Used for ordered list
 
-    let anchorOccurrences = {};
+    let anchorOccurances = {}
 
-    tocEntries.forEach((entry: any, index: number) => {
+    tocEntries.forEach(entry => {
         if (entry.level <= tocConfig.endDepth && entry.level >= startDepth) {
-            let relativeLvl = entry.level - startDepth;
-            let entryText = extractText(entry.text);
-            let anchorText = entryText;
+            let relativeLvl = entry.level - startDepth
+            let entryText = extractText(entry.text)
+            let anchorText = entryText
 
-            if (anchorOccurrences.hasOwnProperty(anchorText)) {
-                anchorOccurrences[anchorText] += 1;
-                anchorText += ' ' + String(anchorOccurrences[anchorText]);
+            if (anchorOccurances.hasOwnProperty(anchorText)) {
+                anchorOccurances[anchorText] += 1
+                anchorText += " " + String(anchorOccurances[anchorText])
             } else {
-                anchorOccurrences[anchorText] = 0;
+                anchorOccurances[anchorText] = 0
             }
 
-            let template = ""
-
-            if (tocConfig.orderedList) {
-              template = tocConfig.template
-                .replace("{marker}", (orderedListMarkerIsOne ? "1" : ++order[relativeLvl]) + ".")
-                .replace("{name}", entryText)
-                .replace("{link}", "#" + slugify(anchorText))
-            } else {
-              template = tocConfig.template
-                .replace("{marker}", tocConfig.marker)
-                .replace("{name}", entryText)
-                .replace("{link}", "#" + slugify(anchorText))
-                .replace("{eol}", docConfig.eol)
-            }
-
-            template = docConfig.tab.repeat(relativeLvl) + template // add tab
-
-            if (!tocConfig.orderedList && tocConfig.markerSkipLast && index === tocEntries.length - 1) {
-              template = template.replace(tocConfig.marker, "") // remove the last marker
-            }
-
-            toc.push(template);
-            if (tocConfig.orderedList) order.fill(0, relativeLvl + 1);
+            let row = [
+                docConfig.tab.repeat(relativeLvl),
+                (tocConfig.orderedList
+                    ? (orderedListMarkerIsOne ? "1" : ++order[relativeLvl]) + "."
+                    : tocConfig.listMarker) + " ",
+                tocConfig.plaintext ? entryText : `[${entryText}](#${slugify(anchorText)})`,
+            ]
+            toc.push(row.join(""))
+            if (tocConfig.orderedList) order.fill(0, relativeLvl + 1)
         }
-    });
-    return toc.join(tocConfig.orderedList ? docConfig.eol : '');
+    })
+    while (/^[ \t]/.test(toc[0])) {
+        toc = toc.slice(1)
+    }
+    return toc.join(docConfig.eol)
 }
 
 /**
@@ -123,149 +110,163 @@ async function generateTocText(): Promise<string> {
  * @param doc a TextDocument
  */
 async function detectTocRanges(doc: vscode.TextDocument): Promise<Array<vscode.Range>> {
-    let tocRanges = [];
-    let newTocText = await generateTocText();
-    let fullText = doc.getText();
+    let tocRanges = []
+    let newTocText = await generateTocText()
+    let fullText = doc.getText()
+    let listRegex = /(^|\r?\n)((?:[-+*]|[0-9]+[.)]) .*(?:\r?\n[ \t]*(?:[-+*]|[0-9]+[.)]) .*)*)/g
+    let match
+    while ((match = listRegex.exec(fullText)) !== null) {
+        let listText = match[2]
 
-    let regexListItem = tocConfig.template
-      .replace(/\s|\[|\]|\(|\)|#/g, "") // remove everything we don't need here
-      .replace("{marker}", `(\\s*${tocConfig.orderedList ? "[0-9]+\\." : "\\" + tocConfig.marker}\\s*)${tocConfig.markerSkipLast ? '?' : ''}`)
-      .replace("{name}", "(\\[[a-zA-Z0-9]+\\])")
-      .replace("{link}", `(\\(${tocConfig.plaintext ? "" : "#"}[a-zA-Z0-9]+\\))`)
-      .replace("{eol}", docConfig.eol)
-    let regexList = new RegExp(`(?!\\n)(${regexListItem})+`, "g")
-    console.log(`(?!\\n)(${regexListItem})+`);
+        // Prevent fake TOC like [#304](https://github.com/yzhang-gh/vscode-markdown/issues/304)
+        let firstLine: string = listText.split(/\r?\n/)[0]
+        if (vscode.workspace.getConfiguration("markdown.extension.toc").get<boolean>("plaintext")) {
+            // A lazy way to check whether it is a link
+            if (firstLine.includes("](")) {
+                continue
+            }
+        } else {
+            if (!firstLine.includes("](#")) {
+                continue
+            }
+        }
 
-    let match;
-    while ((match = regexList.exec(fullText)) !== null) {
-        let listText = match[0];
-
-        if (radioOfCommonPrefix(newTocText, listText) + stringSimilarity.compareTwoStrings(newTocText, listText) > 0.5) {
+        if (
+            radioOfCommonPrefix(newTocText, listText) + stringSimilarity.compareTwoStrings(newTocText, listText) >
+            0.5
+        ) {
             tocRanges.push(
-                new vscode.Range(doc.positionAt(match.index), doc.positionAt(regexList.lastIndex))
-            );
+                new vscode.Range(doc.positionAt(match.index + match[1].length), doc.positionAt(listRegex.lastIndex))
+            )
         }
     }
-    return tocRanges;
+    return tocRanges
 }
 
 function commonPrefixLength(s1, s2) {
-    let minLength = Math.min(s1.length, s2.length);
+    let minLength = Math.min(s1.length, s2.length)
     for (let i = 0; i < minLength; i++) {
         if (s1[i] !== s2[i]) {
-            return i;
+            return i
         }
     }
-    return minLength;
+    return minLength
 }
 
 function radioOfCommonPrefix(s1, s2) {
-    let minLength = Math.min(s1.length, s2.length);
-    let maxLength = Math.max(s1.length, s2.length);
+    let minLength = Math.min(s1.length, s2.length)
+    let maxLength = Math.max(s1.length, s2.length)
 
-    let prefixLength = commonPrefixLength(s1, s2);
+    let prefixLength = commonPrefixLength(s1, s2)
     if (prefixLength < minLength) {
-        return prefixLength / minLength;
+        return prefixLength / minLength
     } else {
-        return minLength / maxLength;
+        return minLength / maxLength
     }
 }
 
 function onWillSave(e: vscode.TextDocumentWillSaveEvent) {
-    if (!tocConfig.updateOnSave) return;
-    if (e.document.languageId == 'markdown') {
-        e.waitUntil(updateToc());
+    if (!tocConfig.updateOnSave) return
+    if (e.document.languageId == "markdown") {
+        e.waitUntil(updateToc())
     }
 }
 
 function loadTocConfig() {
-    let tocSectionCfg = vscode.workspace.getConfiguration('markdown.extension.toc');
-    let tocLevels = tocSectionCfg.get<string>('levels');
-    let matches;
-    if (matches = tocLevels.match(/^([1-6])\.\.([1-6])$/)) {
-        tocConfig.startDepth = Number(matches[1]);
-        tocConfig.endDepth = Number(matches[2]);
+    let tocSectionCfg = vscode.workspace.getConfiguration("markdown.extension.toc")
+    let tocLevels = tocSectionCfg.get<string>("levels")
+    let matches
+    if ((matches = tocLevels.match(/^([1-6])\.\.([1-6])$/))) {
+        tocConfig.startDepth = Number(matches[1])
+        tocConfig.endDepth = Number(matches[2])
     }
-    tocConfig.orderedList = tocSectionCfg.get<boolean>('orderedList');
-    tocConfig.listMarker = tocSectionCfg.get<string>('unorderedList.marker');
-    tocConfig.plaintext = tocSectionCfg.get<boolean>('plaintext');
-    tocConfig.updateOnSave = tocSectionCfg.get<boolean>('updateOnSave');
-    tocConfig.marker = tocSectionCfg.get<string>("marker")
-    tocConfig.markerSkipLast = tocSectionCfg.get<boolean>("markerSkipLast")
-    tocConfig.template = tocSectionCfg.get<string>("template")
+    tocConfig.orderedList = tocSectionCfg.get<boolean>("orderedList")
+    tocConfig.listMarker = tocSectionCfg.get<string>("unorderedList.marker")
+    tocConfig.plaintext = tocSectionCfg.get<boolean>("plaintext")
+    tocConfig.updateOnSave = tocSectionCfg.get<boolean>("updateOnSave")
 
     // Load workspace config
-    let activeEditor = vscode.window.activeTextEditor;
-    docConfig.eol = activeEditor.document.eol === vscode.EndOfLine.CRLF ? '\r\n' : '\n';
+    let activeEditor = vscode.window.activeTextEditor
+    docConfig.eol = activeEditor.document.eol === vscode.EndOfLine.CRLF ? "\r\n" : "\n"
 
-    let tabSize = Number(activeEditor.options.tabSize);
-    if (vscode.workspace.getConfiguration('markdown.extension.list', activeEditor.document.uri).get<string>('indentationSize') === 'adaptive') {
-        tabSize = tocConfig.orderedList ? 3 : 2;
+    let tabSize = Number(activeEditor.options.tabSize)
+    if (
+        vscode.workspace
+            .getConfiguration("markdown.extension.list", activeEditor.document.uri)
+            .get<string>("indentationSize") === "adaptive"
+    ) {
+        tabSize = tocConfig.orderedList ? 3 : 2
     }
 
-    let insertSpaces = activeEditor.options.insertSpaces;
+    let insertSpaces = activeEditor.options.insertSpaces
     if (insertSpaces) {
-        docConfig.tab = ' '.repeat(tabSize);
+        docConfig.tab = " ".repeat(tabSize)
     } else {
-        docConfig.tab = '\t';
+        docConfig.tab = "\t"
     }
 }
 
 function getText(range: vscode.Range): string {
-    return vscode.window.activeTextEditor.document.getText(range);
+    return vscode.window.activeTextEditor.document.getText(range)
 }
 
 function buildToc() {
-    let toc;
-    let editor = vscode.window.activeTextEditor;
+    let toc
+    let editor = vscode.window.activeTextEditor
     if (isMdEditor(editor)) {
-        let lines = editor.document.getText()
-            .replace(/(^|\r?\n)```[\W\w]+?(```|$)/g, '') // Remove code blocks
-            .replace(/^---[\W\w]+?(\r?\n)---/, '') // Remove YAML front matter
-            .split(/\r?\n/g);
+        let lines = editor.document
+            .getText()
+            .replace(/(^|\r?\n)```[\W\w]+?(```|$)/g, "") // Remove code blocks
+            .replace(/^---[\W\w]+?(\r?\n)---/, "") // Remove YAML front matter
+            .split(/\r?\n/g)
         // Transform setext headings to ATX headings
         lines.forEach((lineText, i, arr) => {
-            if (
-                i < arr.length - 1
-                && lineText.match(/^ {0,3}\S.*$/)
-                && arr[i + 1].match(/^ {0,3}(=+|-{2,}) *$/)
-            ) {
-                arr[i] = (arr[i + 1].includes('=') ? '# ' : '## ') + lineText;
+            if (i < arr.length - 1 && lineText.match(/^ {0,3}\S.*$/) && arr[i + 1].match(/^ {0,3}(=+|-{2,}) *$/)) {
+                arr[i] = (arr[i + 1].includes("=") ? "# " : "## ") + lineText
             }
-        });
-        toc = lines.filter(lineText => {
-            return lineText.startsWith('#')
-                && lineText.includes('# ')
-                && !lineText.toLowerCase().includes('<!-- omit in toc -->')
-        }).map(lineText => {
-            let entry = {};
-            let matches = /^(#+) (.*)/.exec(lineText);
-            entry['level'] = matches[1].length;
-            entry['text'] = matches[2].replace(/#+$/, '').trim();
-            return entry;
-        });
+        })
+        toc = lines
+            .filter(lineText => {
+                return (
+                    lineText.startsWith("#") &&
+                    lineText.includes("# ") &&
+                    !lineText.toLowerCase().includes("<!-- omit in toc -->")
+                )
+            })
+            .map(lineText => {
+                let entry = {}
+                let matches = /^(#+) (.*)/.exec(lineText)
+                entry["level"] = matches[1].length
+                entry["text"] = matches[2].replace(/#+$/, "").trim()
+                return entry
+            })
     } else {
-        toc = null;
+        toc = null
     }
-    return toc;
+    return toc
 }
 
 class TocCodeLensProvider implements vscode.CodeLensProvider {
-    public provideCodeLenses(document: vscode.TextDocument, token: vscode.CancellationToken):
-        vscode.CodeLens[] | Thenable<vscode.CodeLens[]> {
-        let lenses: vscode.CodeLens[] = [];
+    public provideCodeLenses(
+        document: vscode.TextDocument,
+        token: vscode.CancellationToken
+    ): vscode.CodeLens[] | Thenable<vscode.CodeLens[]> {
+        let lenses: vscode.CodeLens[] = []
         return detectTocRanges(document).then(tocRanges => {
             for (let tocRange of tocRanges) {
                 generateTocText().then(text => {
-                    let status = getText(tocRange).replace(/\r?\n|\r/g, docConfig.eol) === text ? 'up to date' : 'out of date';
-                    lenses.push(new vscode.CodeLens(tocRange, {
-                        arguments: [],
-                        title: `Table of Contents (${status})`,
-                        command: ''
-                    }));
-                });
+                    let status =
+                        getText(tocRange).replace(/\r?\n|\r/g, docConfig.eol) === text ? "up to date" : "out of date"
+                    lenses.push(
+                        new vscode.CodeLens(tocRange, {
+                            arguments: [],
+                            title: `Table of Contents (${status})`,
+                            command: "",
+                        })
+                    )
+                })
             }
-            return lenses;
-        });
+            return lenses
+        })
     }
 }

--- a/src/toc.ts
+++ b/src/toc.ts
@@ -16,6 +16,9 @@ const tocConfig = {
     updateOnSave: false,
     plaintext: false,
     tabSize: 2,
+    marker: "-",
+    template: "",
+    markerSkipLast: false,
 }
 
 export function activate(context: vscode.ExtensionContext) {
@@ -72,36 +75,47 @@ async function generateTocText(): Promise<string> {
     let startDepth = Math.max(tocConfig.startDepth, Math.min.apply(null, tocEntries.map(h => h.level)))
     let order = new Array(tocConfig.endDepth - startDepth + 1).fill(0) // Used for ordered list
 
-    let anchorOccurances = {}
+    let anchorOccurrences = {}
 
-    tocEntries.forEach(entry => {
+    tocEntries.forEach((entry: any, index: number) => {
         if (entry.level <= tocConfig.endDepth && entry.level >= startDepth) {
             let relativeLvl = entry.level - startDepth
             let entryText = extractText(entry.text)
             let anchorText = entryText
 
-            if (anchorOccurances.hasOwnProperty(anchorText)) {
-                anchorOccurances[anchorText] += 1
-                anchorText += " " + String(anchorOccurances[anchorText])
+            if (anchorOccurrences.hasOwnProperty(anchorText)) {
+                anchorOccurrences[anchorText] += 1
+                anchorText += " " + String(anchorOccurrences[anchorText])
             } else {
-                anchorOccurances[anchorText] = 0
+                anchorOccurrences[anchorText] = 0
             }
 
-            let row = [
-                docConfig.tab.repeat(relativeLvl),
-                (tocConfig.orderedList
-                    ? (orderedListMarkerIsOne ? "1" : ++order[relativeLvl]) + "."
-                    : tocConfig.listMarker) + " ",
-                tocConfig.plaintext ? entryText : `[${entryText}](#${slugify(anchorText)})`,
-            ]
-            toc.push(row.join(""))
+            let template = ""
+
+            if (tocConfig.orderedList) {
+                template = tocConfig.template
+                    .replace("{marker}", (orderedListMarkerIsOne ? "1" : ++order[relativeLvl]) + ".")
+                    .replace("{name}", entryText)
+                    .replace("{link}", "#" + slugify(anchorText))
+            } else {
+                template = tocConfig.template
+                    .replace("{marker}", tocConfig.marker)
+                    .replace("{name}", entryText)
+                    .replace("{link}", "#" + slugify(anchorText))
+                    .replace("{eol}", docConfig.eol)
+            }
+
+            template = docConfig.tab.repeat(relativeLvl) + template // add tab
+
+            if (!tocConfig.orderedList && tocConfig.markerSkipLast && index === tocEntries.length - 1) {
+                template = template.replace(tocConfig.marker, "") // remove the last marker
+            }
+
+            toc.push(template)
             if (tocConfig.orderedList) order.fill(0, relativeLvl + 1)
         }
     })
-    while (/^[ \t]/.test(toc[0])) {
-        toc = toc.slice(1)
-    }
-    return toc.join(docConfig.eol)
+    return toc.join(tocConfig.orderedList ? docConfig.eol : "")
 }
 
 /**
@@ -113,31 +127,30 @@ async function detectTocRanges(doc: vscode.TextDocument): Promise<Array<vscode.R
     let tocRanges = []
     let newTocText = await generateTocText()
     let fullText = doc.getText()
-    let listRegex = /(^|\r?\n)((?:[-+*]|[0-9]+[.)]) .*(?:\r?\n[ \t]*(?:[-+*]|[0-9]+[.)]) .*)*)/g
-    let match
-    while ((match = listRegex.exec(fullText)) !== null) {
-        let listText = match[2]
 
-        // Prevent fake TOC like [#304](https://github.com/yzhang-gh/vscode-markdown/issues/304)
-        let firstLine: string = listText.split(/\r?\n/)[0]
-        if (vscode.workspace.getConfiguration("markdown.extension.toc").get<boolean>("plaintext")) {
-            // A lazy way to check whether it is a link
-            if (firstLine.includes("](")) {
-                continue
-            }
-        } else {
-            if (!firstLine.includes("](#")) {
-                continue
-            }
-        }
+    let regexListItem = tocConfig.template
+        .replace(/\s|\[|\]|\(|\)|#/g, "") // remove everything we don't need here
+        .replace(
+            "{marker}",
+            `(\\s*${tocConfig.orderedList ? "[0-9]+\\." : "\\" + tocConfig.marker}\\s*)${
+                tocConfig.markerSkipLast ? "?" : ""
+            }`
+        )
+        .replace("{name}", "(\\[[a-zA-Z0-9]+\\])")
+        .replace("{link}", `(\\(${tocConfig.plaintext ? "" : "#"}[a-zA-Z0-9]+\\))`)
+        .replace("{eol}", docConfig.eol)
+    let regexList = new RegExp(`(?!\\n)(${regexListItem})+`, "g")
+    console.log(`(?!\\n)(${regexListItem})+`)
+
+    let match
+    while ((match = regexList.exec(fullText)) !== null) {
+        let listText = match[0]
 
         if (
             radioOfCommonPrefix(newTocText, listText) + stringSimilarity.compareTwoStrings(newTocText, listText) >
             0.5
         ) {
-            tocRanges.push(
-                new vscode.Range(doc.positionAt(match.index + match[1].length), doc.positionAt(listRegex.lastIndex))
-            )
+            tocRanges.push(new vscode.Range(doc.positionAt(match.index), doc.positionAt(regexList.lastIndex)))
         }
     }
     return tocRanges
@@ -184,6 +197,9 @@ function loadTocConfig() {
     tocConfig.listMarker = tocSectionCfg.get<string>("unorderedList.marker")
     tocConfig.plaintext = tocSectionCfg.get<boolean>("plaintext")
     tocConfig.updateOnSave = tocSectionCfg.get<boolean>("updateOnSave")
+    tocConfig.marker = tocSectionCfg.get<string>("marker")
+    tocConfig.markerSkipLast = tocSectionCfg.get<boolean>("markerSkipLast")
+    tocConfig.template = tocSectionCfg.get<string>("template")
 
     // Load workspace config
     let activeEditor = vscode.window.activeTextEditor

--- a/src/toc.ts
+++ b/src/toc.ts
@@ -15,7 +15,7 @@ const tocConfig = {
   orderedList: false,
   updateOnSave: false,
   plaintext: false,
-   tabSize: 2,
+  tabSize: 2,
   marker: "-",
   template: "",
   markerSkipLast: false,

--- a/test/toc.test.ts
+++ b/test/toc.test.ts
@@ -1,310 +1,320 @@
-import { workspace, Selection } from 'vscode';
-import { testMdFile, defaultConfigs, testCommand } from './testUtils';
+import { workspace, Selection } from "vscode";
+import { testMdFile, defaultConfigs, testCommand } from "./testUtils";
 
 let previousConfigs = Object.assign({}, defaultConfigs);
 
 suite("TOC.", () => {
-    suiteSetup(async () => {
-        // 💩 Preload file to prevent the first test to be treated timeout
-        await workspace.openTextDocument(testMdFile);
+  suiteSetup(async () => {
+    // 💩 Preload file to prevent the first test to be treated timeout
+    await workspace.openTextDocument(testMdFile);
 
-        for (let key in previousConfigs) {
-            if (previousConfigs.hasOwnProperty(key)) {
-                previousConfigs[key] = workspace.getConfiguration('', null).get(key);
-            }
-        }
-    });
+    for (let key in previousConfigs) {
+      if (previousConfigs.hasOwnProperty(key)) {
+        previousConfigs[key] = workspace.getConfiguration("", null).get(key);
+      }
+    }
+  });
 
-    suiteTeardown(async () => {
-        for (let key in previousConfigs) {
-            if (previousConfigs.hasOwnProperty(key)) {
-                await workspace.getConfiguration('', null).update(key, previousConfigs[key], true);
-            }
-        }
-    });
+  suiteTeardown(async () => {
+    for (let key in previousConfigs) {
+      if (previousConfigs.hasOwnProperty(key)) {
+        await workspace
+          .getConfiguration("", null)
+          .update(key, previousConfigs[key], true);
+      }
+    }
+  });
 
-    test("Create", done => {
-        testCommand('markdown.extension.toc.create', {},
-            [
-                '# Section 1',
-                '',
-                '## Section 1.1',
-                '',
-                '# Section 2',
-                '',
-                ''
-            ],
-            new Selection(6, 0, 6, 0),
-            [
-                '# Section 1',
-                '',
-                '## Section 1.1',
-                '',
-                '# Section 2',
-                '',
-                '- [Section 1](#section-1)',
-                '  - [Section 1.1](#section-11)',
-                '- [Section 2](#section-2)'
-            ],
-            new Selection(8, 25, 8, 25)).then(done, done);
-    });
+  test("Create", done => {
+    testCommand(
+      "markdown.extension.toc.create",
+      {},
+      ["# Section 1", "", "## Section 1.1", "", "# Section 2", "", ""],
+      new Selection(6, 0, 6, 0),
+      [
+        "# Section 1",
+        "",
+        "## Section 1.1",
+        "",
+        "# Section 2",
+        "",
+        "- [Section 1](#section-1)",
+        "  - [Section 1.1](#section-11)",
+        "- [Section 2](#section-2)"
+      ],
+      new Selection(8, 25, 8, 25)
+    ).then(done, done);
+  });
 
-    test("Update", done => {
-        testCommand('markdown.extension.toc.update', {},
-            [
-                '# Section 1',
-                '',
-                '## Section 1.1',
-                '',
-                '# Section 2',
-                '',
-                '## Section 2.1',
-                '',
-                '- [Section 1](#section-1)',
-                '  - [Section 1.1](#section-11)',
-                '- [Section 2](#section-2)'
-            ],
-            new Selection(0, 0, 0, 0),
-            [
-                '# Section 1',
-                '',
-                '## Section 1.1',
-                '',
-                '# Section 2',
-                '',
-                '## Section 2.1',
-                '',
-                '- [Section 1](#section-1)',
-                '  - [Section 1.1](#section-11)',
-                '- [Section 2](#section-2)',
-                '  - [Section 2.1](#section-21)'
-            ],
-            new Selection(0, 0, 0, 0)).then(done, done);
-    });
+  test("Update", done => {
+    testCommand(
+      "markdown.extension.toc.update",
+      {},
+      [
+        "# Section 1",
+        "",
+        "## Section 1.1",
+        "",
+        "# Section 2",
+        "",
+        "## Section 2.1",
+        "",
+        "- [Section 1](#section-1)",
+        "  - [Section 1.1](#section-11)",
+        "- [Section 2](#section-2)"
+      ],
+      new Selection(0, 0, 0, 0),
+      [
+        "# Section 1",
+        "",
+        "## Section 1.1",
+        "",
+        "# Section 2",
+        "",
+        "## Section 2.1",
+        "",
+        "- [Section 1](#section-1)",
+        "  - [Section 1.1](#section-11)",
+        "- [Section 2](#section-2)",
+        "  - [Section 2.1](#section-21)"
+      ],
+      new Selection(0, 0, 0, 0)
+    ).then(done, done);
+  });
 
-    test("Create (levels 2..3)", done => {
-        testCommand('markdown.extension.toc.create',
-            {
-                "markdown.extension.toc.levels": "2..3"
-            },
-            [
-                '# Section 1',
-                '',
-                '## Section 1.1',
-                '',
-                '### Section 1.1.1',
-                '',
-                '#### Section 1.1.1.1',
-                '',
-                '# Section 2',
-                '',
-                '## Section 2.1',
-                '',
-                '### Section 2.1.1',
-                '',
-                '#### Section 2.1.1.1',
-                '',
-                ''
-            ],
-            new Selection(16, 0, 16, 0),
-            [
-                '# Section 1',
-                '',
-                '## Section 1.1',
-                '',
-                '### Section 1.1.1',
-                '',
-                '#### Section 1.1.1.1',
-                '',
-                '# Section 2',
-                '',
-                '## Section 2.1',
-                '',
-                '### Section 2.1.1',
-                '',
-                '#### Section 2.1.1.1',
-                '',
-                '- [Section 1.1](#section-11)',
-                '  - [Section 1.1.1](#section-111)',
-                '- [Section 2.1](#section-21)',
-                '  - [Section 2.1.1](#section-211)',
-            ],
-            new Selection(19, 33, 19, 33)).then(done, done);
-    });
+  test("Create Custom", done => {
+    testCommand(
+      "markdown.extension.toc.create",
+      {
+        "markdown.extension.toc.marker": "·",
+        "markdown.extension.toc.markerSkipLast": true,
+        "markdown.extension.toc.template": "[{name}](#{link}) {marker}"
+      },
+      ["# Section 1", "", "## Section 1.1", "", "# Section 2", "", ""],
+      new Selection(6, 0, 6, 0),
+      [
+        "# Section 1",
+        "",
+        "## Section 1.1",
+        "",
+        "# Section 2",
+        "",
+        "[Section 1](#section-1) · [Section 1.1](#section-11) · [Section 2](#section-2)"
+      ],
+      new Selection(8, 25, 8, 25)
+    ).then(done, done);
+  });
 
-    test("Update (levels 2..3)", done => {
-        testCommand('markdown.extension.toc.update',
-            {
-                "markdown.extension.toc.levels": "2..3"
-            },
-            [
-                '# Section 1',
-                '',
-                '## Section 1.1',
-                '',
-                '### Section 1.1.1',
-                '',
-                '#### Section 1.1.1.1',
-                '',
-                '# Section 2',
-                '',
-                '## Section 2.1',
-                '',
-                '- [Section 1.1](#section-11)',
-                '  - [Section 1.1.1](#section-111)',
-                '- [Section 2.1](#section-21)',
-                '  - [Section 2.1.1](#section-211)',
-            ],
-            new Selection(0, 0, 0, 0),
-            [
-                '# Section 1',
-                '',
-                '## Section 1.1',
-                '',
-                '### Section 1.1.1',
-                '',
-                '#### Section 1.1.1.1',
-                '',
-                '# Section 2',
-                '',
-                '## Section 2.1',
-                '',
-                '- [Section 1.1](#section-11)',
-                '  - [Section 1.1.1](#section-111)',
-                '- [Section 2.1](#section-21)'
-            ],
-            new Selection(0, 0, 0, 0)).then(done, done);
-    });
+  test("Create (levels 2..3)", done => {
+    testCommand(
+      "markdown.extension.toc.create",
+      {
+        "markdown.extension.toc.levels": "2..3"
+      },
+      [
+        "# Section 1",
+        "",
+        "## Section 1.1",
+        "",
+        "### Section 1.1.1",
+        "",
+        "#### Section 1.1.1.1",
+        "",
+        "# Section 2",
+        "",
+        "## Section 2.1",
+        "",
+        "### Section 2.1.1",
+        "",
+        "#### Section 2.1.1.1",
+        "",
+        ""
+      ],
+      new Selection(16, 0, 16, 0),
+      [
+        "# Section 1",
+        "",
+        "## Section 1.1",
+        "",
+        "### Section 1.1.1",
+        "",
+        "#### Section 1.1.1.1",
+        "",
+        "# Section 2",
+        "",
+        "## Section 2.1",
+        "",
+        "### Section 2.1.1",
+        "",
+        "#### Section 2.1.1.1",
+        "",
+        "- [Section 1.1](#section-11)",
+        "  - [Section 1.1.1](#section-111)",
+        "- [Section 2.1](#section-21)",
+        "  - [Section 2.1.1](#section-211)"
+      ],
+      new Selection(19, 33, 19, 33)
+    ).then(done, done);
+  });
 
-    test("Create 中文", done => {
-        testCommand('markdown.extension.toc.create', {},
-            [
-                '# Section 中文',
-                '',
-                '## Section 1.1',
-                '',
-                '# Section 2',
-                '',
-                ''
-            ],
-            new Selection(6, 0, 6, 0),
-            [
-                '# Section 中文',
-                '',
-                '## Section 1.1',
-                '',
-                '# Section 2',
-                '',
-                '- [Section 中文](#section-%E4%B8%AD%E6%96%87)',
-                '  - [Section 1.1](#section-11)',
-                '- [Section 2](#section-2)'
-            ],
-            new Selection(8, 25, 8, 25)).then(done, done);
-    });
+  test("Update (levels 2..3)", done => {
+    testCommand(
+      "markdown.extension.toc.update",
+      {
+        "markdown.extension.toc.levels": "2..3"
+      },
+      [
+        "# Section 1",
+        "",
+        "## Section 1.1",
+        "",
+        "### Section 1.1.1",
+        "",
+        "#### Section 1.1.1.1",
+        "",
+        "# Section 2",
+        "",
+        "## Section 2.1",
+        "",
+        "- [Section 1.1](#section-11)",
+        "  - [Section 1.1.1](#section-111)",
+        "- [Section 2.1](#section-21)",
+        "  - [Section 2.1.1](#section-211)"
+      ],
+      new Selection(0, 0, 0, 0),
+      [
+        "# Section 1",
+        "",
+        "## Section 1.1",
+        "",
+        "### Section 1.1.1",
+        "",
+        "#### Section 1.1.1.1",
+        "",
+        "# Section 2",
+        "",
+        "## Section 2.1",
+        "",
+        "- [Section 1.1](#section-11)",
+        "  - [Section 1.1.1](#section-111)",
+        "- [Section 2.1](#section-21)"
+      ],
+      new Selection(0, 0, 0, 0)
+    ).then(done, done);
+  });
 
-    test("Slugify. `a.b` c => ab-c", done => {
-        testCommand('markdown.extension.toc.create', {},
-            [
-                '# `a.b` c',
-                '',
-                ''
-            ],
-            new Selection(2, 0, 2, 0),
-            [
-                '# `a.b` c',
-                '',
-                '- [`a.b` c](#ab-c)'
-            ],
-            new Selection(2, 18, 2, 18)).then(done, done);
-    });
+  test("Create 中文", done => {
+    testCommand(
+      "markdown.extension.toc.create",
+      {},
+      ["# Section 中文", "", "## Section 1.1", "", "# Section 2", "", ""],
+      new Selection(6, 0, 6, 0),
+      [
+        "# Section 中文",
+        "",
+        "## Section 1.1",
+        "",
+        "# Section 2",
+        "",
+        "- [Section 中文](#section-%E4%B8%AD%E6%96%87)",
+        "  - [Section 1.1](#section-11)",
+        "- [Section 2](#section-2)"
+      ],
+      new Selection(8, 25, 8, 25)
+    ).then(done, done);
+  });
 
-    test("Setext headings", done => {
-        testCommand('markdown.extension.toc.create', {},
-            [
-                'Section 1',
-                '===',
-                '',
-                'Section 1.1',
-                '---',
-                '',
-                ''
-            ],
-            new Selection(6, 0, 6, 0),
-            [
-                'Section 1',
-                '===',
-                '',
-                'Section 1.1',
-                '---',
-                '',
-                '- [Section 1](#section-1)',
-                '  - [Section 1.1](#section-11)'
-            ],
-            new Selection(7, 30, 7, 30)).then(done, done);
-    });
+  test("Slugify. `a.b` c => ab-c", done => {
+    testCommand(
+      "markdown.extension.toc.create",
+      {},
+      ["# `a.b` c", "", ""],
+      new Selection(2, 0, 2, 0),
+      ["# `a.b` c", "", "- [`a.b` c](#ab-c)"],
+      new Selection(2, 18, 2, 18)
+    ).then(done, done);
+  });
 
-    test("Non-Latin symbols", done => {
-        testCommand('markdown.extension.toc.create',
-            {
-                "markdown.extension.toc.githubCompatibility": true
-            },
-            [
-                '# Секция 1',
-                '',
-                '## Секция 1.1',
-                '',
-                ''
-            ],
-            new Selection(4, 0, 4, 0),
-            [
-                '# Секция 1',
-                '',
-                '## Секция 1.1',
-                '',
-                '- [Секция 1](#Секция-1)',
-                '  - [Секция 1.1](#Секция-11)'
-            ],
-            new Selection(5, 28, 5, 28)).then(done, done);
-    });
+  test("Setext headings", done => {
+    testCommand(
+      "markdown.extension.toc.create",
+      {},
+      ["Section 1", "===", "", "Section 1.1", "---", "", ""],
+      new Selection(6, 0, 6, 0),
+      [
+        "Section 1",
+        "===",
+        "",
+        "Section 1.1",
+        "---",
+        "",
+        "- [Section 1](#section-1)",
+        "  - [Section 1.1](#section-11)"
+      ],
+      new Selection(7, 30, 7, 30)
+    ).then(done, done);
+  });
 
-    test("Update multiple TOCs", done => {
-        testCommand('markdown.extension.toc.update',
-            {
-                "markdown.extension.toc.githubCompatibility": true
-            },
-            [
-                '# Head 1',
-                '# Head 2',
-                '',
-                '- [Head 1](#head-1)',
-                '- [Head 2](#head-2)',
-                '- [Head 3](#head-3)',
-                '',
-                '- [Head 1](#head-1)',
-                '- [Head 2](#head-2)',
-                '- [Head 3](#head-3)',
-                '',
-                '# Head 3',
-                '# Head 4'
-            ],
-            new Selection(0, 0, 0, 0),
-            [
-                '# Head 1',
-                '# Head 2',
-                '',
-                '- [Head 1](#head-1)',
-                '- [Head 2](#head-2)',
-                '- [Head 3](#head-3)',
-                '- [Head 4](#head-4)',
-                '',
-                '- [Head 1](#head-1)',
-                '- [Head 2](#head-2)',
-                '- [Head 3](#head-3)',
-                '- [Head 4](#head-4)',
-                '',
-                '# Head 3',
-                '# Head 4'
-            ],
-            new Selection(0, 0, 0, 0)).then(done, done);
-    });
+  test("Non-Latin symbols", done => {
+    testCommand(
+      "markdown.extension.toc.create",
+      {
+        "markdown.extension.toc.githubCompatibility": true
+      },
+      ["# Секция 1", "", "## Секция 1.1", "", ""],
+      new Selection(4, 0, 4, 0),
+      [
+        "# Секция 1",
+        "",
+        "## Секция 1.1",
+        "",
+        "- [Секция 1](#Секция-1)",
+        "  - [Секция 1.1](#Секция-11)"
+      ],
+      new Selection(5, 28, 5, 28)
+    ).then(done, done);
+  });
+
+  test("Update multiple TOCs", done => {
+    testCommand(
+      "markdown.extension.toc.update",
+      {
+        "markdown.extension.toc.githubCompatibility": true
+      },
+      [
+        "# Head 1",
+        "# Head 2",
+        "",
+        "- [Head 1](#head-1)",
+        "- [Head 2](#head-2)",
+        "- [Head 3](#head-3)",
+        "",
+        "- [Head 1](#head-1)",
+        "- [Head 2](#head-2)",
+        "- [Head 3](#head-3)",
+        "",
+        "# Head 3",
+        "# Head 4"
+      ],
+      new Selection(0, 0, 0, 0),
+      [
+        "# Head 1",
+        "# Head 2",
+        "",
+        "- [Head 1](#head-1)",
+        "- [Head 2](#head-2)",
+        "- [Head 3](#head-3)",
+        "- [Head 4](#head-4)",
+        "",
+        "- [Head 1](#head-1)",
+        "- [Head 2](#head-2)",
+        "- [Head 3](#head-3)",
+        "- [Head 4](#head-4)",
+        "",
+        "# Head 3",
+        "# Head 4"
+      ],
+      new Selection(0, 0, 0, 0)
+    ).then(done, done);
+  });
 });


### PR DESCRIPTION
To-Do:

- [] CHANGELOG.md
- [] Version update
- [] README
- [] Update tests

It works pretty good with a few bugs:

#### it has problems recognizing everything before a custom template, so its ignored

```md
[Titled](httpasdas:7asdas) <- [Titled](#titled) <- [Title2](#title2) <- [Title3](#title3)  

## Titled

## Title2

## Title3
```

#### When enabling `orderedList` and a headline has duplicated names it duplicates the entries somehow

```md
1. [Titled](#titled)
2. [Title2](#title2)
3. [Title3](#title3)
4. [Title3](#title3-1)
4.  [Title3](#title3-1)
5.  [Title3](#title3-1)
6.  [Title3](#title3-1)

## Titled

## Title2

## Title3

## Title3
```

Related issues: #403 