### PR TITLE
Prefer unused links for reference link label completions

### DIFF
--- a/src/completion.ts
+++ b/src/completion.ts
@@ -176,11 +176,13 @@ class MdCompletionItemProvider implements CompletionItemProvider {
                     if ((match = /^\[([^\]]*?)\]: (\S*)( .*)?/.exec(curr)) !== null) {
                         const ref = match[1];
                         let item = new CompletionItem(ref, CompletionItemKind.Reference);
-                        item.documentation = match[2];
+                        const usages = usageCounts.get(ref) || 0;
+                        item.documentation = new MarkdownString(match[2]);
+                        item.detail = usages === 1 ? `1 usage`  : `${usages} usages`;
                         // prefer unused items
                         // We need to `sortText` in the else case as well due to:
                         // https://github.com/Microsoft/vscode/issues/66109#issuecomment-451873316
-                        item.sortText = !usageCounts.has(ref) ? `!!!-${ref}` : item.sortText = ref;
+                        item.sortText = usages === 0 ? `!!!-${ref}` : item.sortText = ref;
                         
                         item.range = range;
                         prev.push(item);

--- a/src/completion.ts
+++ b/src/completion.ts
@@ -4,7 +4,6 @@ import * as sizeOf from 'image-size';
 import * as path from 'path';
 import { CancellationToken, CompletionContext, CompletionItem, CompletionItemKind, CompletionItemProvider, CompletionList, ExtensionContext, languages, MarkdownString, Position, ProviderResult, Range, SnippetString, TextDocument, workspace } from 'vscode';
 import { mdDocSelector } from './util';
-import { stringify } from 'querystring';
 
 export function activate(context: ExtensionContext) {
     context.subscriptions.push(languages.registerCompletionItemProvider(mdDocSelector, new MdCompletionItemProvider(), '(', '\\', '/', '['));

--- a/src/completion.ts
+++ b/src/completion.ts
@@ -178,9 +178,7 @@ class MdCompletionItemProvider implements CompletionItemProvider {
                         const usages = usageCounts.get(ref) || 0;
                         item.documentation = new MarkdownString(match[2]);
                         item.detail = usages === 1 ? `1 usage`  : `${usages} usages`;
-                        // prefer unused items
-                        // We need to `sortText` in the else case as well due to:
-                        // https://github.com/Microsoft/vscode/issues/66109#issuecomment-451873316
+                        // Prefer unused items
                         item.sortText = usages === 0 ? `0-${ref}` : item.sortText = `1-${ref}`;
                         
                         item.range = range;

--- a/src/completion.ts
+++ b/src/completion.ts
@@ -181,7 +181,7 @@ class MdCompletionItemProvider implements CompletionItemProvider {
                         // prefer unused items
                         // We need to `sortText` in the else case as well due to:
                         // https://github.com/Microsoft/vscode/issues/66109#issuecomment-451873316
-                        item.sortText = usages === 0 ? `!!!-${ref}` : item.sortText = ref;
+                        item.sortText = usages === 0 ? `0-${ref}` : item.sortText = `1-${ref}`;
                         
                         item.range = range;
                         prev.push(item);


### PR DESCRIPTION
The completion for reference link labels will now prioritize unused link labels.

Labels that are used at least once are not affected by this change.

Further, I've made the link in the documentation popup clickable.

Debatable change: I included a usage count in the details of the completion items.