### PR TITLE
Autocompletion for heading links

### DIFF
--- a/src/completion.ts
+++ b/src/completion.ts
@@ -189,6 +189,61 @@ class MdCompletionItemProvider implements CompletionItemProvider {
 
                 res(refLabels);
             });
+        } else if (/\[[^\]]*\]\(#[^\)]*$/.test(lineTextBefore)) {
+            /* ┌──────────────────────────┐
+               │ Anchor tags from headers │
+               └──────────────────────────┘ */
+            let startIndex = lineTextBefore.lastIndexOf('(');
+            let endPosition = position;
+
+            let addClosingParen = false;
+            if (/^([^\) ]+\s*|^\s*)\)/.test(lineTextAfter)) {
+                // try to detect if user wants to replace a link (i.e. matching closing paren and )
+                // Either: ... <CURSOR> something <whitespace> )
+                //     or: ... <CURSOR> <whitespace> )
+                //     or: ... <CURSOR> )     (endPosition assignment is a no-op for this case)
+
+                // in every case, we want to remove all characters after the cursor and before that first closing paren
+                endPosition = position.with({character: + endPosition.character + lineTextAfter.indexOf(')')});
+            } else {
+                // If no closing paren is found, replace all trailing non-white-space chars and add a closing paren
+                // distance to first non-whitespace or EOL
+                const toReplace = (lineTextAfter.search(/(?<=^\S+)(\s|$)/))
+                endPosition = position.with({character: + endPosition.character + toReplace});
+
+                addClosingParen = true;
+            }
+            
+            const range = new Range(position.with({ character: startIndex + 1 }), endPosition);
+            const linesToPreview = 8;
+
+            return new Promise((res, _) => {
+                const lines = document.getText().split(/\r?\n/);
+                
+                let refLabels = lines.reduce((prev, curr, lineNumber) => {
+                    let match;
+                    if ((match = /^#+\s+(.*)\s*$/.exec(curr)) !== null) {
+                        const title = match[2];
+                        const anchorName = title.replace(/ +/g, "-").toLowerCase();
+                        let item = new CompletionItem('#' + anchorName, CompletionItemKind.Reference);
+                        
+                        if (addClosingParen) {
+                            item.insertText = item.label + ')';
+                        }
+                        const context = document.getText(new Range(new Position(lineNumber + 1, 0), new Position(lineNumber + 1 + linesToPreview, 0)));
+                        
+                        
+                        const markdown = `${curr}\n${context}`;
+                        item.documentation = new MarkdownString(markdown);
+                        
+                        item.range = range;
+                        prev.push(item);
+                    }
+                    return prev;
+                }, []);
+
+                res(refLabels);
+            });
         } else {
             return [];
         }

--- a/src/completion.ts
+++ b/src/completion.ts
@@ -6,7 +6,7 @@ import { CancellationToken, CompletionContext, CompletionItem, CompletionItemKin
 import { mdDocSelector } from './util';
 
 export function activate(context: ExtensionContext) {
-    context.subscriptions.push(languages.registerCompletionItemProvider(mdDocSelector, new MdCompletionItemProvider(), '(', '\\', '/', '['));
+    context.subscriptions.push(languages.registerCompletionItemProvider(mdDocSelector, new MdCompletionItemProvider(), '(', '\\', '/', '[', '#'));
 }
 
 class MdCompletionItemProvider implements CompletionItemProvider {


### PR DESCRIPTION
This change implements autocompletion for links to sections within the same document:

```markdown

## Heading Test

[See here](#)   <-- Autocomplete


### Some other heading here

```

Suggests `#heading-test` and `#some-other-heading-here`

It also works correctly if the auto-completion is invoked on a pre-existing link.