### PR TITLE
katex macros support added

### DIFF
--- a/package.json
+++ b/package.json
@@ -300,6 +300,11 @@
                     "type": "boolean",
                     "default": false,
                     "description": "%config.syntax.plainTheme.description%"
+                },
+                "markdown.extension.katex.macros": {
+                    "type": "object",
+                    "default": "{}",
+                    "description": "%config.katex.macros.description%"
                 }
             }
         },

--- a/package.nls.json
+++ b/package.nls.json
@@ -27,6 +27,7 @@
     "config.print.onFileSave.description": "Markdown: Print current document to HTML when file is saved",
     "config.syntax.decorations.description": "Add syntax decorations",
     "config.syntax.plainTheme.description": "Only take effect when `extension.syntax.decorations` is enabled",
+    "config.katex.macros.description": "user-defined KaTeX macros",
     "showMe": "Show Me",
     "dismiss": "Dismiss",
     "noValidMarkdownFile": "No valid Markdown file",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,14 +13,16 @@ import * as decorations from './syntaxDecorations';
 import * as tableFormatter from './tableFormatter';
 import * as toc from './toc';
 import { getNewFeatureMsg, showChangelog } from './util';
+import {workspace} from 'vscode';
 
 export function activate(context: ExtensionContext) {
     activateMdExt(context);
 
     return {
         extendMarkdownIt(md) {
+
             return md.use(require('markdown-it-task-lists'))
-                .use(require('@neilsustc/markdown-it-katex'), { "throwOnError": false });
+                .use(require('@neilsustc/markdown-it-katex'), { throwOnError: false, macros : workspace.getConfiguration('markdown.extension.katex').get<object>('macros')  });
         }
     }
 }


### PR DESCRIPTION
I added support for katex user defined macros #426 . The only thing missing I think is the translation of the description of the new option `markdown.extension.katex.macros`, but I let @yzhang-gh ^^