### PR TITLE
macros settings need a deep copy

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -24,7 +24,7 @@ export function activate(context: ExtensionContext) {
             return md.use(require('markdown-it-task-lists'))
                 .use(require('@neilsustc/markdown-it-katex'), {
                     throwOnError: false,
-                    macros: workspace.getConfiguration('markdown.extension.katex').get<object>('macros')
+                    macros: JSON.parse(JSON.stringify(workspace.getConfiguration('markdown.extension.katex').get<object>('macros')))
                 });
         }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -24,6 +24,7 @@ export function activate(context: ExtensionContext) {
             return md.use(require('markdown-it-task-lists'))
                 .use(require('@neilsustc/markdown-it-katex'), {
                     throwOnError: false,
+                    // Make a deep copy as `macros` will be modified by KaTeX during initialization
                     macros: JSON.parse(JSON.stringify(workspace.getConfiguration('markdown.extension.katex').get<object>('macros')))
                 });
         }

--- a/src/print.ts
+++ b/src/print.ts
@@ -37,7 +37,7 @@ async function initMdIt() {
     }).use(mdtl)
         .use(mdkt, {
             throwOnError: false,
-            macros: workspace.getConfiguration('markdown.extension.katex').get<object>('macros')
+            macros: JSON.parse(JSON.stringify(workspace.getConfiguration('markdown.extension.katex').get<object>('macros')))
         });
 
     addNamedHeaders(md);


### PR DESCRIPTION
#445

Don't know why but I just copied the default macros of `\\\\` and now it works.
https://github.com/KaTeX/KaTeX/blob/c8f2783ca82b48edda1673dffabcf99f55f8bb7f/src/macros.js#L673