### PR TITLE
Refined math

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -1,0 +1,43 @@
+{
+    "comments": {
+        // symbols used for start and end a block comment. Remove this entry if your language does not support block comments
+        "blockComment": [
+            "<!--",
+            "-->"
+        ]
+    },
+    // symbols used as brackets
+    "brackets": [
+        ["{", "}"],
+        ["[", "]"],
+        ["(", ")"]
+    ],
+    "autoClosingPairs": [{
+            "open": "{",
+            "close": "}"
+        },
+        {
+            "open": "[",
+            "close": "]"
+        },
+        {
+            "open": "(",
+            "close": ")"
+        }
+    ],
+    "surroundingPairs": [
+        ["(", ")"],
+        ["[", "]"],
+        ["{", "}"],
+        ["`", "`"],
+        ["_", "_"],
+        ["*", "*"]
+    ],
+    "folding": {
+        "offSide": true,
+        "markers": {
+            "start": "^\\s*<!--\\s*#?region\\b.*-->",
+            "end": "^\\s*<!--\\s*#?endregion\\b.*-->"
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -28,6 +28,25 @@
     ],
     "main": "./dist/extension",
     "contributes": {
+        "languages": [{
+            "id": "markdown",
+            "aliases": [
+                "Markdown",
+                "markdown"
+            ],
+            "extensions": [
+                ".md",
+                ".mkd",
+                ".mdwn",
+                ".mdown",
+                ".markdown",
+                ".markdn",
+                ".mdtxt",
+                ".mdtext",
+                ".workbook"
+            ],
+            "configuration": "./language-configuration.json"
+        }],
         "commands": [
             {
                 "command": "markdown.extension.toc.create",

--- a/package.json
+++ b/package.json
@@ -159,6 +159,16 @@
                 "when": "editorTextFocus && editorLangId == markdown"
             },
             {
+                "command": "markdown.extension.toggleInlineMath",
+                "key": "ctrl+m",
+                "when": "editorTextFocus && editorLangId == markdown"
+            },
+            {
+                "command": "markdown.extension.toggleDisplayedMath",
+                "key": "ctrl+shift+m",
+                "when": "editorTextFocus && editorLangId == markdown"
+            },
+            {
                 "command": "markdown.extension.togglePreview",
                 "key": "ctrl+shift+v",
                 "mac": "cmd+shift+v",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,6 +6,7 @@ import { ExtensionContext, languages, window } from 'vscode';
 import * as completion from './completion';
 import * as formatting from './formatting';
 import * as listEditing from './listEditing';
+import * as mathEditing from './mathEditing'
 import localize from './localize';
 import * as preview from './preview';
 import * as print from './print';
@@ -32,6 +33,8 @@ export function activate(context: ExtensionContext) {
 }
 
 function activateMdExt(context: ExtensionContext) {
+    // Toggle Math block shortcut
+    mathEditing.activate(context);
     // Override `Enter`, `Tab` and `Backspace` keys
     listEditing.activate(context);
     // Shortcuts

--- a/src/mathEditing.ts
+++ b/src/mathEditing.ts
@@ -1,0 +1,145 @@
+'use strict'
+
+import { commands, ExtensionContext, Range, window, Selection, Position } from 'vscode';
+
+export function activate(context: ExtensionContext) {
+    context.subscriptions.push(
+        commands.registerCommand('markdown.extension.toggleInlineMath', toggleInlineMath),
+        commands.registerCommand('markdown.extension.toggleDisplayedMath', toggleDisplayedMath),
+    );
+}
+
+function toggleInlineMath() {
+    let editor = window.activeTextEditor;
+    let cursorPosBeforeInsertion = editor.selection.active;
+    
+    /**
+     * Function name: isInInlineMath
+     * Purpose: return true and the range when the cursor is in an inline math block.
+     * Assume that user is not using selection, i.e. 
+     * editor.selection.start == editor.selection.end
+     * 
+     * Time complexity: O(1)~O(n) where n is the length of current line.
+     * 
+     * Algorithm Pseudocode:
+     *  1. Initialize leftPos,cursor,rightPos
+     *  2. Found if there is a left `$` and a right `$`, if both, return true.
+     */
+    function isInInlineMath(): [boolean, Range] {
+        let line = editor.document.lineAt(cursorPosBeforeInsertion).text;
+        let leftPos = cursorPosBeforeInsertion.character - 1;
+        let rightPos = cursorPosBeforeInsertion.character;
+        let leftDollarFound = false;
+        let rightDollarFound = false;
+        while(leftPos >= 0 && rightPos < line.length) {
+            if(!leftDollarFound) {
+                if (line[leftPos--] === '$') {
+                    leftDollarFound = true;
+                }
+            }
+            if(!rightDollarFound) {
+                if (line[rightPos++] === '$') {
+                    rightDollarFound = true;
+                }
+            }
+            if (leftDollarFound && rightDollarFound) {
+                leftPos++;
+                rightPos--;
+                break;
+            }
+        }
+        if (leftDollarFound && rightDollarFound) {
+            // Note $ ... $ (with trailing whitespace) is not an inline math block
+            if (line[leftPos+1] !== ' ' && rightPos[rightPos-1] !== ' ') {
+                let leftDollarPosition = new Position(cursorPosBeforeInsertion.line, leftPos);
+                let rightDollarPosition = new Position(cursorPosBeforeInsertion.line, rightPos+1);
+                return [true, new Range(leftDollarPosition, rightDollarPosition)];
+            }
+        }
+        return [false, null];
+    }
+
+    let [isInInline, inlineRange] = isInInlineMath()
+    if (isInInline) {
+        // Cancel the block
+        editor.edit(editBuilder => {
+            editBuilder.delete(inlineRange);
+        });
+    } else {
+        // Create the block
+        editor.edit(editBuilder => {
+            editBuilder.insert(cursorPosBeforeInsertion, ' $$ ');
+        }).then(() => {
+            let cursorPosAfterInsertion = editor.selection.active;
+            let mathPosition = cursorPosAfterInsertion.with(cursorPosAfterInsertion.line, cursorPosAfterInsertion.character - 2)
+            editor.selection = new Selection(mathPosition, mathPosition);
+        });
+    }
+}
+
+function toggleDisplayedMath() {
+    let editor = window.activeTextEditor;
+    let cursorPosBeforeInsertion = editor.selection.active;
+
+    /**
+     * Function name: isInDisplayedMath
+     * Purpose: return true and the range when the cursor is in a displayed math block.
+     * Assume that user is not using selection, i.e. 
+     * editor.selection.start == editor.selection.end
+     * 
+     * Time complexity: O(1)~O(n) where n is the number of lines of the file.
+     * 
+     * Algorithm Pseudocode:
+     *  1. Initialize upPos,cursor,downPos
+     *  2. Found if there is a up `$$` and a down `$$`, if both, return true.
+     */
+    function isInDisplayedMath(): [boolean, Range] {
+        let upPos = cursorPosBeforeInsertion.line - 1;
+        let downPos = cursorPosBeforeInsertion.line + 1;
+        let upDollarFound = false;
+        let downDollarFound = false;
+        while(upPos >= 0 && downPos < editor.document.lineCount) {
+            if(!upDollarFound) {
+                if (editor.document.lineAt(upPos).text == '$$') {
+                    upDollarFound = true;
+                } else {
+                    upPos--;
+                }
+            }
+            if(!downDollarFound) {
+                if (editor.document.lineAt(downPos).text == '$$') {
+                    downDollarFound = true;
+                } else {
+                    downPos++;
+                }
+            }
+            if (upDollarFound && downDollarFound) {
+                break;
+            }
+        }
+        if (upDollarFound && downDollarFound) {
+            let upDollarPosition = new Position(upPos, 0);
+            let downDollarPosition = new Position(downPos, 2);
+            return [true, new Range(upDollarPosition, downDollarPosition)];
+        }
+        return [false, null];
+    }
+
+    let [isInDisplayed, displayedRange] = isInDisplayedMath()
+    if (isInDisplayed) {
+        // Cancel the block
+        editor.edit(editBuilder => {
+            editBuilder.delete(displayedRange);
+        });
+    }
+    else {
+        // Create the block
+        editor.edit(editBuilder => {
+            editBuilder.insert(cursorPosBeforeInsertion, `\n$$\n\n$$\n`);
+        }).then(() => {
+            let cursorPosAfterInsertion = editor.selection.active;
+            let mathPosition = cursorPosAfterInsertion.with(cursorPosAfterInsertion.line - 2, 0)
+            editor.selection = new Selection(mathPosition, mathPosition);
+        });
+    }
+}

--- a/src/mathEditing.ts
+++ b/src/mathEditing.ts
@@ -13,6 +13,23 @@ function toggleInlineMath() {
     let editor = window.activeTextEditor;
     let cursorPosBeforeInsertion = editor.selection.active;
     
+    let [isInInline, inlineRange] = isInInlineMath();
+    if (isInInline) {
+        // Cancel the block
+        editor.edit(editBuilder => {
+            editBuilder.delete(inlineRange);
+        });
+    } else {
+        // Create the block
+        editor.edit(editBuilder => {
+            editBuilder.insert(cursorPosBeforeInsertion, ' $$ ');
+        }).then(() => {
+            let cursorPosAfterInsertion = editor.selection.active;
+            let mathPosition = cursorPosAfterInsertion.with(cursorPosAfterInsertion.line, cursorPosAfterInsertion.character - 2)
+            editor.selection = new Selection(mathPosition, mathPosition);
+        });
+    }
+
     /**
      * Function name: isInInlineMath
      * Purpose: return true and the range when the cursor is in an inline math block.
@@ -58,28 +75,29 @@ function toggleInlineMath() {
         }
         return [false, null];
     }
-
-    let [isInInline, inlineRange] = isInInlineMath()
-    if (isInInline) {
-        // Cancel the block
-        editor.edit(editBuilder => {
-            editBuilder.delete(inlineRange);
-        });
-    } else {
-        // Create the block
-        editor.edit(editBuilder => {
-            editBuilder.insert(cursorPosBeforeInsertion, ' $$ ');
-        }).then(() => {
-            let cursorPosAfterInsertion = editor.selection.active;
-            let mathPosition = cursorPosAfterInsertion.with(cursorPosAfterInsertion.line, cursorPosAfterInsertion.character - 2)
-            editor.selection = new Selection(mathPosition, mathPosition);
-        });
-    }
 }
 
 function toggleDisplayedMath() {
     let editor = window.activeTextEditor;
     let cursorPosBeforeInsertion = editor.selection.active;
+
+    let [isInDisplayed, displayedRange] = isInDisplayedMath();
+    if (isInDisplayed) {
+        // Cancel the block
+        editor.edit(editBuilder => {
+            editBuilder.delete(displayedRange);
+        });
+    }
+    else {
+        // Create the block
+        editor.edit(editBuilder => {
+            editBuilder.insert(cursorPosBeforeInsertion, `\n$$\n\n$$\n`);
+        }).then(() => {
+            let cursorPosAfterInsertion = editor.selection.active;
+            let mathPosition = cursorPosAfterInsertion.with(cursorPosAfterInsertion.line - 2, 0)
+            editor.selection = new Selection(mathPosition, mathPosition);
+        });
+    }
 
     /**
      * Function name: isInDisplayedMath
@@ -123,23 +141,5 @@ function toggleDisplayedMath() {
             return [true, new Range(upDollarPosition, downDollarPosition)];
         }
         return [false, null];
-    }
-
-    let [isInDisplayed, displayedRange] = isInDisplayedMath()
-    if (isInDisplayed) {
-        // Cancel the block
-        editor.edit(editBuilder => {
-            editBuilder.delete(displayedRange);
-        });
-    }
-    else {
-        // Create the block
-        editor.edit(editBuilder => {
-            editBuilder.insert(cursorPosBeforeInsertion, `\n$$\n\n$$\n`);
-        }).then(() => {
-            let cursorPosAfterInsertion = editor.selection.active;
-            let mathPosition = cursorPosAfterInsertion.with(cursorPosAfterInsertion.line - 2, 0)
-            editor.selection = new Selection(mathPosition, mathPosition);
-        });
     }
 }


### PR DESCRIPTION
#421

@yzhang-gh Thanks for the suggestions, let's discuss the detail here.

> Sorry, I don't get the point. What feature would you like to implement?

Exactly the `Ctrl+M` shortcut to quickly add a math block and move the cursor to the middle of the block.

> For example, the current behaviour can be described as:
> `|` -> `$|$` -> `$$ | $$` -> `|` -> ... (toggle with `ctrl + m`)
> 
> My previous idea is to add another state
> 
> ```
> $$
> |
> $$
> ```
> 
> between `$$ | $$` and `|`.
> 
> Could you elaborate your expected behaviour like this?

Your idea is very good, but I think the user may need the cancel out the previously created math block, i.e. there are two states `created` & `canceled`, the user can switch between them. So I keep the function of `Ctrl+M` for inline blocks only and add another shortcut `Ctrl+Shift+M` for displayed blocks.

`Ctrl+M` will create an inline math block and move the cursor to the middle, and the user may write some tex. If the user wants to delete the math block quickly, he just presses `Ctrl+M` again. The same applies to the `Ctrl+Shift+M` for displayed math.

Do you like this way? If you would prefer only the `Ctrl+M` shortcut, I think it's well, too.

For KaTeX rendering, we are currently using `markdwon-it-katex`. For highlighting, what are we using now? I think we can learn from it and switch correctly between three states:
```
State 0: nothing
State 1: $|$
State 2: $$|$$
State 3: 
$$
|
$$
```
We can loop between them, for example: `0->1->2->3->0->...`