### PR TITLE
⚡️ Stop loading on all workspaces with README.md

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,15 @@
     "license": "MIT",
     "activationEvents": [
         "onLanguage:markdown",
-        "workspaceContains:README.md"
+        "onCommand:markdown.extension.toc.create",
+        "onCommand:markdown.extension.toc.update",
+        "onCommand:markdown.extension.printToHtml",
+        "onCommand:markdown.extension.editing.toggleCodeSpan",
+        "onCommand:markdown.extension.editing.toggleMath",
+        "onCommand:markdown.extension.editing.toggleMathReverse",
+        "onCommand:markdown.extension.editing.toggleList",
+        "onCommand:markdown.extension.togglePreview",
+        "onCommand:markdown.extension.togglePreviewToSide"
     ],
     "main": "./dist/extension",
     "contributes": {


### PR DESCRIPTION
VSCode lazy loads extensions, listening on `activationEvents`
and evaluating JS + activate() when one of those events happens.
The idea is to prevent loading everything on startup.

Before, Markdown All in One would activate on any workspace with a
`README.md`, even if you never opened a markdown file.

Now, it only activates if you open a markdown file.

This commit also adds all commands that can be run outside of a markdown
file - those that don't have `editorLangId == markdown`. However it
might be safe to remove them since they don't seem to do anything
outside of markdown.

# Reproduction
1. make a folder with README.md & test.js
```
mkdir ~/example
touch ~/example/README.md
touch ~/example/test.js
```
2. Run extension, open folder `~/example`
3. Run `Developer: Show Running Extensions`
## Before
![image](https://user-images.githubusercontent.com/3344958/64496158-d3909880-d256-11e9-8cee-d9efa126f758.png)

## Now
![image](https://user-images.githubusercontent.com/3344958/64496166-d7241f80-d256-11e9-849b-978ac2a68473.png)
