### PR TITLE
fix #233 don't convert image paths for data URIs

### DIFF
--- a/src/print.ts
+++ b/src/print.ts
@@ -140,7 +140,7 @@ async function print(type: string) {
 
     if (configToBase64) {
         body = body.replace(imgTagRegex, function (_, p1, p2, p3) {
-            if (p2.startsWith('http')) {
+            if (p2.startsWith('http') || p2.startsWith('data:')) {
                 return _;
             }
 
@@ -161,7 +161,7 @@ async function print(type: string) {
         });
     } else if (configAbsPath) {
         body = body.replace(imgTagRegex, function (_, p1, p2, p3) {
-            if (p2.startsWith('http')) {
+            if (p2.startsWith('http') || p2.startsWith('data:')) {
                 return _;
             }
 


### PR DESCRIPTION
Previously it required setting `markdown.extension.print.absoluteImgPath` to `false` to get printing to HTML to correctly produce images embedded with data URIs. This would break non-data URI images.

Now local path and data URI images can coexist without changing settings.

Example data URI use:  
`![picture](data:image/png;base64,...image data encoded in base64...=)`