### PR TITLE
Do not update list markers past headings

### DIFF
--- a/src/listEditing.ts
+++ b/src/listEditing.ts
@@ -275,6 +275,12 @@ function findNextMarkerLineNumber(line?: number): number {
     }
     while (line < editor.document.lineCount) {
         const lineText = editor.document.lineAt(line).text;
+
+        if (lineText.startsWith('#')) {
+            // Don't go searching past any headings
+            return -1;
+        }
+
         if (/^\s*[0-9]+[.)] +/.exec(lineText) !== null) {
             return line;
         }

--- a/src/test/suite/listEditing.test.ts
+++ b/src/test/suite/listEditing.test.ts
@@ -87,6 +87,28 @@ suite("List editing.", () => {
         testCommand('markdown.extension.onBackspaceKey', {}, ['- [ ]  item1'], new Selection(0, 7, 0, 7), ['- [ ] item1'], new Selection(0, 6, 0, 6)).then(done, done);
     });
 
+    test("Backspace key. github#411", done => {
+        testCommand('markdown.extension.onBackspaceKey', {},
+        [
+            '1. one',
+            '2. ',
+            '',
+            '# Heading',
+            '',
+            '3. three'
+        ],
+        new Selection(1, 3, 1, 3),
+        [
+            '1. one',
+            '   ',
+            '',
+            '# Heading',
+            '',
+            '3. three'
+        ],
+        new Selection(1, 3, 1, 3)).then(done, done);
+    });
+
     test("Tab key. 1: '- |'", done => {
         testCommand('markdown.extension.onTabKey', {}, ['- item1'], new Selection(0, 2, 0, 2), ['    - item1'], new Selection(0, 6, 0, 6)).then(done, done);
     });

--- a/src/test/suite/listEditing.test.ts
+++ b/src/test/suite/listEditing.test.ts
@@ -87,28 +87,6 @@ suite("List editing.", () => {
         testCommand('markdown.extension.onBackspaceKey', {}, ['- [ ]  item1'], new Selection(0, 7, 0, 7), ['- [ ] item1'], new Selection(0, 6, 0, 6)).then(done, done);
     });
 
-    test("Backspace key. github#411", done => {
-        testCommand('markdown.extension.onBackspaceKey', {},
-        [
-            '1. one',
-            '2. ',
-            '',
-            '# Heading',
-            '',
-            '3. three'
-        ],
-        new Selection(1, 3, 1, 3),
-        [
-            '1. one',
-            '   ',
-            '',
-            '# Heading',
-            '',
-            '3. three'
-        ],
-        new Selection(1, 3, 1, 3)).then(done, done);
-    });
-
     test("Tab key. 1: '- |'", done => {
         testCommand('markdown.extension.onTabKey', {}, ['- item1'], new Selection(0, 2, 0, 2), ['    - item1'], new Selection(0, 6, 0, 6)).then(done, done);
     });

--- a/src/test/suite/listRenumbering.test.ts
+++ b/src/test/suite/listRenumbering.test.ts
@@ -124,6 +124,28 @@ suite("Ordered list renumbering.", () => {
             new Selection(1, 0, 1, 0)).then(done, done);
     });
 
+    test("Backspace key. github#411", done => {
+        testCommand('markdown.extension.onBackspaceKey', {},
+        [
+            '1. one',
+            '2. ',
+            '',
+            '# Heading',
+            '',
+            '3. three'
+        ],
+        new Selection(1, 3, 1, 3),
+        [
+            '1. one',
+            '   ',
+            '',
+            '# Heading',
+            '',
+            '3. three'
+        ],
+        new Selection(1, 3, 1, 3)).then(done, done);
+    });
+
     test("Tab key. Fix ordered marker. 1", done => {
         testCommand('markdown.extension.onTabKey', {},
             [


### PR DESCRIPTION
This should fix #411 and generally finding the next marker line number after a heading should not happen (this does not seem to break any other tests).