### PR TITLE
🐛 #589 '%20' instead of '&#32;' (follow-up)

### DIFF
--- a/src/completion.ts
+++ b/src/completion.ts
@@ -398,7 +398,7 @@ class MdCompletionItemProvider implements CompletionItemProvider {
             return workspace.findFiles('**/*.{png,jpg,jpeg,svg,gif}', '**/node_modules/**').then(uris => {
                 let items = uris.map(imgUri => {
                     const label = path.relative(basePath, imgUri.fsPath).replace(/\\/g, '/');
-                    let item = new CompletionItem(label.replace(/ /g, '&#32;'), CompletionItemKind.File);
+                    let item = new CompletionItem(label.replace(/ /g, '%20'), CompletionItemKind.File);
 
                     //// Add image preview
                     let dimensions: { width: number; height: number; };
@@ -413,7 +413,7 @@ class MdCompletionItemProvider implements CompletionItemProvider {
                         dimensions.height = Number(dimensions.height * maxWidth / dimensions.width);
                         dimensions.width = maxWidth;
                     }
-                    item.documentation = new MarkdownString(`![${label}](${imgUri.fsPath.replace(/ /g, '&#32;')}|width=${dimensions.width},height=${dimensions.height})`);
+                    item.documentation = new MarkdownString(`![${label}](${imgUri.fsPath.replace(/ /g, '%20')}|width=${dimensions.width},height=${dimensions.height})`);
 
                     item.sortText = label.replace(/\./g, '{');
 


### PR DESCRIPTION
Fixes #589 

aa502b797a12fad63f228e537b39cd7d03631143 fixed the issue (thank you @yzhang-gh!), however there is a similar problem in image path completion. This PR fixes it.