### PR TITLE
use 'for k of Object.keys()` instead of checking `hasOwnProperty`

### DIFF
--- a/src/completion.ts
+++ b/src/completion.ts
@@ -367,25 +367,23 @@ class MdCompletionItemProvider implements CompletionItemProvider {
         }
         let configMacros = workspace.getConfiguration('markdown.extension.katex', resource).get<object>('macros');
         var macroItems: CompletionItem[] = [];
-        for (const cmd in configMacros) {
-            if (configMacros.hasOwnProperty(cmd)) {
-                const expansion: string = configMacros[cmd];
+        for (const cmd of Object.keys(configMacros)) {
+            const expansion: string = configMacros[cmd];
             let item = new CompletionItem(cmd, CompletionItemKind.Function);
 
-                // Find the number of arguments in the expansion 
-                let numArgs = 0;
-                for (let i = 1; i < 10; i++) {
-                    if (!expansion.includes(`#${i}`)) {
-                        numArgs = i - 1;
-                        break;
+            // Find the number of arguments in the expansion
+            let numArgs = 0;
+            for (let i = 1; i < 10; i++) {
+                if (!expansion.includes(`#${i}`)) {
+                    numArgs = i - 1;
+                    break;
                 }
             }
 
-                item.insertText = new SnippetString(cmd.slice(1) + [...Array(numArgs).keys()].map(i => `\{$${i + 1}\}`).join(""));
-                macroItems.push(item);
-            }
+            item.insertText = new SnippetString(cmd.slice(1) + [...Array(numArgs).keys()].map(i => `\{$${i + 1}\}`).join(""));
+            macroItems.push(item);
         }
-        
+
         this.mathCompletions = [...c1, ...c2, ...c3, envSnippet, ...macroItems];
 
         // Sort
@@ -402,8 +400,8 @@ class MdCompletionItemProvider implements CompletionItemProvider {
         let excludePatterns = ['**/node_modules', '**/bower_components', '**/*.code-search'];
         if (workspace.workspaceFolders !== undefined) {
             const configExclude = workspace.getConfiguration('search', workspace.workspaceFolders[0].uri).get<object>('exclude');
-            for (const key in configExclude) {
-                if (configExclude.hasOwnProperty(key) && configExclude[key] === true) {
+            for (const key of Object.keys(configExclude)) {
+                if (configExclude[key] === true) {
                     excludePatterns.push(key);
                 }
             }

--- a/src/test/suite/formatting.test.ts
+++ b/src/test/suite/formatting.test.ts
@@ -8,18 +8,14 @@ suite("Formatting.", () => {
         // 💩 Preload file to prevent the first test to be treated timeout
         await workspace.openTextDocument(testMdFile);
 
-        for (let key in previousConfigs) {
-            if (previousConfigs.hasOwnProperty(key)) {
-                previousConfigs[key] = workspace.getConfiguration('', null).get(key);
-            }
+        for (let key of Object.keys(previousConfigs)) {
+            previousConfigs[key] = workspace.getConfiguration('', null).get(key);
         }
     });
 
     suiteTeardown(async () => {
-        for (let key in previousConfigs) {
-            if (previousConfigs.hasOwnProperty(key)) {
-                await workspace.getConfiguration('', null).update(key, previousConfigs[key], true);
-            }
+        for (let key of Object.keys(previousConfigs)) {
+            await workspace.getConfiguration('', null).update(key, previousConfigs[key], true);
         }
     });
 

--- a/src/test/suite/listEditing.fallback.test.ts
+++ b/src/test/suite/listEditing.fallback.test.ts
@@ -8,18 +8,14 @@ suite("No list editing.", () => {
         // 💩 Preload file to prevent the first test timeout
         await workspace.openTextDocument(testMdFile);
 
-        for (let key in previousConfigs) {
-            if (previousConfigs.hasOwnProperty(key)) {
-                previousConfigs[key] = workspace.getConfiguration('', null).get(key);
-            }
+        for (let key of Object.keys(previousConfigs)) {
+            previousConfigs[key] = workspace.getConfiguration('', null).get(key);
         }
     });
 
     suiteTeardown(async () => {
-        for (let key in previousConfigs) {
-            if (previousConfigs.hasOwnProperty(key)) {
-                await workspace.getConfiguration('', null).update(key, previousConfigs[key], true);
-            }
+        for (let key of Object.keys(previousConfigs)) {
+            await workspace.getConfiguration('', null).update(key, previousConfigs[key], true);
         }
     });
 

--- a/src/test/suite/listEditing.test.ts
+++ b/src/test/suite/listEditing.test.ts
@@ -8,18 +8,14 @@ suite("List editing.", () => {
         // 💩 Preload file to prevent the first test timeout
         await workspace.openTextDocument(testMdFile);
 
-        for (let key in previousConfigs) {
-            if (previousConfigs.hasOwnProperty(key)) {
-                previousConfigs[key] = workspace.getConfiguration('', null).get(key);
-            }
+        for (let key of Object.keys(previousConfigs)) {
+            previousConfigs[key] = workspace.getConfiguration('', null).get(key);
         }
     });
 
     suiteTeardown(async () => {
-        for (let key in previousConfigs) {
-            if (previousConfigs.hasOwnProperty(key)) {
-                await workspace.getConfiguration('', null).update(key, previousConfigs[key], true);
-            }
+        for (let key of Object.keys(previousConfigs)) {
+            await workspace.getConfiguration('', null).update(key, previousConfigs[key], true);
         }
     });
 

--- a/src/test/suite/listRenumbering.test.ts
+++ b/src/test/suite/listRenumbering.test.ts
@@ -8,18 +8,14 @@ suite("Ordered list renumbering.", () => {
         // 💩 Preload file to prevent the first test timeout
         await workspace.openTextDocument(testMdFile);
 
-        for (let key in previousConfigs) {
-            if (previousConfigs.hasOwnProperty(key)) {
-                previousConfigs[key] = workspace.getConfiguration('', null).get(key);
-            }
+        for (let key of Object.keys(previousConfigs)) {
+            previousConfigs[key] = workspace.getConfiguration('', null).get(key);
         }
     });
 
     suiteTeardown(async () => {
-        for (let key in previousConfigs) {
-            if (previousConfigs.hasOwnProperty(key)) {
-                await workspace.getConfiguration('', null).update(key, previousConfigs[key], true);
-            }
+        for (let key of Object.keys(previousConfigs)) {
+            await workspace.getConfiguration('', null).update(key, previousConfigs[key], true);
         }
     });
 

--- a/src/test/suite/slugify.test.ts
+++ b/src/test/suite/slugify.test.ts
@@ -21,21 +21,17 @@ suite("Slugify function.", () => {
         "foo & < >  \"foo\"": "foo---foo"
     }
 
-    for (const heading in headings) {
-        if (headings.hasOwnProperty(heading)) {
-            const slug = headings[heading];
-            test(`(VSCode) ${heading} → ${slug}`, () => {
-                assert.strictEqual(util.slugify(heading, false), slug);
-            });
-        }
+    for (const heading of Object.keys(headings)) {
+        const slug = headings[heading];
+        test(`(VSCode) ${heading} → ${slug}`, () => {
+            assert.strictEqual(util.slugify(heading, false), slug);
+        });
     }
 
-    for (const heading in headings_github) {
-        if (headings_github.hasOwnProperty(heading)) {
-            const slug = headings_github[heading];
-            test(`(GitHub) ${heading} → ${slug}`, () => {
-                assert.strictEqual(util.slugify(heading, true), slug);
-            });
-        }
+    for (const heading of Object.keys(headings_github)) {
+        const slug = headings_github[heading];
+        test(`(GitHub) ${heading} → ${slug}`, () => {
+            assert.strictEqual(util.slugify(heading, true), slug);
+        });
     }
 });

--- a/src/test/suite/tableFormatter.test.ts
+++ b/src/test/suite/tableFormatter.test.ts
@@ -8,18 +8,14 @@ suite("Table formatter.", () => {
         // 💩 Preload file to prevent the first test to be treated timeout
         await workspace.openTextDocument(testMdFile);
 
-        for (let key in previousConfigs) {
-            if (previousConfigs.hasOwnProperty(key)) {
-                previousConfigs[key] = workspace.getConfiguration('', null).get(key);
-            }
+        for (let key of Object.keys(previousConfigs)) {
+            previousConfigs[key] = workspace.getConfiguration('', null).get(key);
         }
     });
 
     suiteTeardown(async () => {
-        for (let key in previousConfigs) {
-            if (previousConfigs.hasOwnProperty(key)) {
-                await workspace.getConfiguration('', null).update(key, previousConfigs[key], true);
-            }
+        for (let key of Object.keys(previousConfigs)) {
+            await workspace.getConfiguration('', null).update(key, previousConfigs[key], true);
         }
     });
 

--- a/src/test/suite/testUtils.ts
+++ b/src/test/suite/testUtils.ts
@@ -24,15 +24,11 @@ export let defaultConfigs = {
 
 export async function testCommand(command: string, configs, lines: string[], selection: Selection, expLines: string[], expSelection: Selection) {
     let tempConfigs = Object.assign({}, defaultConfigs);
-    for (let key in configs) {
-        if (configs.hasOwnProperty(key)) {
-            tempConfigs[key] = configs[key];
-        }
+    for (let key of Object.keys(configs)) {
+        tempConfigs[key] = configs[key];
     }
-    for (let key in tempConfigs) {
-        if (tempConfigs.hasOwnProperty(key)) {
-            await workspace.getConfiguration().update(key, tempConfigs[key], true);
-        }
+    for (let key of Object.keys(tempConfigs)) {
+        await workspace.getConfiguration().update(key, tempConfigs[key], true);
     }
     return workspace.openTextDocument(testMdFile).then(document => {
         return window.showTextDocument(document).then(editor => {

--- a/src/test/suite/toc.test.ts
+++ b/src/test/suite/toc.test.ts
@@ -8,18 +8,14 @@ suite("TOC.", () => {
         // 💩 Preload file to prevent the first test to be treated timeout
         await workspace.openTextDocument(testMdFile);
 
-        for (let key in previousConfigs) {
-            if (previousConfigs.hasOwnProperty(key)) {
-                previousConfigs[key] = workspace.getConfiguration('', null).get(key);
-            }
+        for (let key of Object.keys(previousConfigs)) {
+            previousConfigs[key] = workspace.getConfiguration('', null).get(key);
         }
     });
 
     suiteTeardown(async () => {
-        for (let key in previousConfigs) {
-            if (previousConfigs.hasOwnProperty(key)) {
-                await workspace.getConfiguration('', null).update(key, previousConfigs[key], true);
-            }
+        for (let key of Object.keys(previousConfigs)) {
+            await workspace.getConfiguration('', null).update(key, previousConfigs[key], true);
         }
     });
 

--- a/src/toc.ts
+++ b/src/toc.ts
@@ -81,17 +81,15 @@ function getExcludedHeadings(doc: TextDocument): { level: number, text: string }
     const docWorkspace = workspace.getWorkspaceFolder(doc.uri);
 
     let omittedTocPerFile = {};
-    for (const filePath in configObj) {
-        if (configObj.hasOwnProperty(filePath)) {
-            let normedPath: string;
-            //// Converts paths to absolute paths if a workspace is opened
-            if (docWorkspace !== undefined && !path.isAbsolute(filePath)) {
-                normedPath = normalizePath(path.join(docWorkspace.uri.fsPath, filePath));
-            } else {
-                normedPath = normalizePath(filePath);
-            }
-            omittedTocPerFile[normedPath] = [...(omittedTocPerFile[normedPath] || []), ...configObj[filePath]];
+    for (const filePath of Object.keys(configObj)) {
+        let normedPath: string;
+        //// Converts paths to absolute paths if a workspace is opened
+        if (docWorkspace !== undefined && !path.isAbsolute(filePath)) {
+            normedPath = normalizePath(path.join(docWorkspace.uri.fsPath, filePath));
+        } else {
+            normedPath = normalizePath(filePath);
         }
+        omittedTocPerFile[normedPath] = [...(omittedTocPerFile[normedPath] || []), ...configObj[filePath]];
     }
 
     const currentFile = normalizePath(doc.fileName);


### PR DESCRIPTION
```javascript
for (k of Object.keys(obj) {
    //
}
```

is **faster**, and easier to read and write than 

```javascript
for (k in obj) {
    if (obj.hasOwnProperty(k)) {
        //
    }
}
```

See https://stackoverflow.com/questions/30326452/why-is-object-keys-faster-than-hasownproperty