### PR TITLE
Properly remove Markdown formatting from ToC entries (fixes #515)

### DIFF
--- a/src/toc.ts
+++ b/src/toc.ts
@@ -133,8 +133,15 @@ async function generateTocText(doc: TextDocument): Promise<string> {
         if (entry.level <= tocConfig.endDepth && entry.level >= startDepth) {
             let relativeLvl = entry.level - startDepth;
             
-            let entryText = extractText(entry.text)
-            let slug = slugify(entryText);
+            let entryText = entry.text;
+            
+            //// `[text](link)` → `text`
+            entryText=entryText.replace(/\[([^\]]*)\]\([^\)]*\)/, (_, g1) => g1)
+
+            //// Issue #515
+            entryText = entryText.replace(/\[([^\]]*)\](?:\[[^\]]*\])*/, (_, g1) => g1);
+            
+            let slug = slugify(extractText(entryText));
 
             if (anchorOccurances.hasOwnProperty(slug)) {
                 anchorOccurances[slug] += 1;

--- a/src/toc.ts
+++ b/src/toc.ts
@@ -132,9 +132,9 @@ async function generateTocText(doc: TextDocument): Promise<string> {
     tocEntries.forEach(entry => {
         if (entry.level <= tocConfig.endDepth && entry.level >= startDepth) {
             let relativeLvl = entry.level - startDepth;
-            //// `[text](link)` → `text`
-            let entryText = entry.text.replace(/\[([^\]]*)\]\([^\)]*\)/, (_, g1) => g1);
-            let slug = slugify(extractText(entryText));
+            
+            let entryText = extractText(entry.text)
+            let slug = slugify(entryText);
 
             if (anchorOccurances.hasOwnProperty(slug)) {
                 anchorOccurances[slug] += 1;

--- a/src/util.ts
+++ b/src/util.ts
@@ -109,8 +109,12 @@ export function showChangelog() {
  * @param text
  */
 export function extractText(text: string) {
+    //// `[text](link)` → `text`
+    text=text.replace(/\[([^\]]*)\]\([^\)]*\)/, (_, g1) => g1)
+
     //// Issue #515
-    text = text.replace(/\[([^\]]*)\]\[[^\]]*\]/, (_, g1) => g1);
+    text = text.replace(/\[([^\]]*)\](?:\[[^\]]*\])*/, (_, g1) => g1);
+
     //// Escape leading `1.` and `1)` (#567, #585)
     text = text.replace(/^([\d]+)(\.)/, (_, g1) => g1 + '%dot%');
     text = text.replace(/^([\d]+)(\))/, (_, g1) => g1 + '%par%');


### PR DESCRIPTION
#515 looks to have been caused by `extractText()` not actually being called when creating the entry label, only for the link:

https://github.com/yzhang-gh/vscode-markdown/blob/c83296e52bee7326d1c56731f0e670289e5c3a62/src/toc.ts#L136-L137

(Looks like it was changed in https://github.com/yzhang-gh/vscode-markdown/commit/fe6a14f9763a9f24d5e94e93f6fdb569db97a05c#diff-3a050df20b3a1c2ba3272cb808d6ab8b, previously it did call it)

Here I've just changed it so it calls `extractText()` again. (I also moved the regex that had been there, which removes links, to `extractText()`, because it seems like it probably should have been there in the first place...? Not sure if there's a reason it wasn't put there or not)