### PR TITLE
Remove shortcut-style links from headers in ToC

### DIFF
--- a/src/test/suite/toc.test.ts
+++ b/src/test/suite/toc.test.ts
@@ -503,6 +503,8 @@ suite("TOC.", () => {
             [
                 '# [text](link)',
                 '# [text2][label]',
+                '# [text3][]',
+                '# [text4]',
                 '# **bold**',
                 '# *it1* _it2_',
                 '# `code`',
@@ -511,10 +513,12 @@ suite("TOC.", () => {
                 '',
                 ''
             ],
-            new Selection(8, 0, 8, 0),
+            new Selection(10, 0, 10, 0),
             [
                 '# [text](link)',
                 '# [text2][label]',
+                '# [text3][]',
+                '# [text4]',
                 '# **bold**',
                 '# *it1* _it2_',
                 '# `code`',
@@ -523,12 +527,14 @@ suite("TOC.", () => {
                 '',
                 '- [text](#text)',
                 '- [text2](#text2)',
+                '- [text3](#text3)',
+                '- [text4](#text4)',
                 '- [**bold**](#bold)',
                 '- [*it1* _it2_](#it1-it2)',
                 '- [`code`](#code)',
                 '- [1. Heading](#1-heading)',
                 '- [1) Heading](#1-heading-1)'
             ],
-            new Selection(14, 28, 14, 28)).then(done, done);
+            new Selection(18, 28, 18, 28)).then(done, done);
     });
 });

--- a/src/toc.ts
+++ b/src/toc.ts
@@ -134,10 +134,10 @@ async function generateTocText(doc: TextDocument): Promise<string> {
             let relativeLvl = entry.level - startDepth;
 
             //// Remove certain Markdown syntaxes
-            //// `[text](link)` → `text`
+            //// `[text](link)`
             let headingText = entry.text.replace(/\[([^\]]*)\]\([^\)]*\)/, (_, g1) => g1);
-            //// `[text][label]` → `text`
-            headingText = headingText.replace(/\[([^\]]*)\]\[[^\)]*\]/, (_, g1) => g1);
+            //// `[text][label]` and `[text]` → `text` → `text`
+            headingText = headingText.replace(/\[([^\]]*)\](?:\[[^\]]*\])*/, (_, g1) => g1);
 
             let slug = slugify(mdHeadingToPlaintext(entry.text));
 

--- a/src/toc.ts
+++ b/src/toc.ts
@@ -134,9 +134,9 @@ async function generateTocText(doc: TextDocument): Promise<string> {
             let relativeLvl = entry.level - startDepth;
 
             //// Remove certain Markdown syntaxes
-            //// `[text](link)`
+            //// `[text](link)` → `text`
             let headingText = entry.text.replace(/\[([^\]]*)\]\([^\)]*\)/, (_, g1) => g1);
-            //// `[text][label]` and `[text]` → `text` → `text`
+            //// `[text][label]` and `[text]` → `text`
             headingText = headingText.replace(/\[([^\]]*)\](?:\[[^\]]*\])*/, (_, g1) => g1);
 
             let slug = slugify(mdHeadingToPlaintext(entry.text));

--- a/src/util.ts
+++ b/src/util.ts
@@ -111,6 +111,8 @@ export function showChangelog() {
  * @param text
  */
 export function mdHeadingToPlaintext(text: string) {
+    //// `[text](link)`
+    text = text.replace(/\[([^\]]*)\]\([^\)]*\)/, (_, g1) => g1);
     //// Issue #515
     text = text.replace(/\[([^\]]*)\](?:\[[^\]]*\])*/, (_, g1) => g1);
     //// Escape leading `1.` and `1)` (#567, #585)

--- a/src/util.ts
+++ b/src/util.ts
@@ -112,7 +112,7 @@ export function showChangelog() {
  */
 export function mdHeadingToPlaintext(text: string) {
     //// Issue #515
-    text = text.replace(/\[([^\]]*)\]\[[^\]]*\]/, (_, g1) => g1);
+    text = text.replace(/\[([^\]]*)\](?:\[[^\]]*\])*/, (_, g1) => g1);
     //// Escape leading `1.` and `1)` (#567, #585)
     text = text.replace(/^([\d]+)(\.)/, (_, g1) => g1 + '%dot%');
     text = text.replace(/^([\d]+)(\))/, (_, g1) => g1 + '%par%');


### PR DESCRIPTION
Currently, the regex used to match links does not match shortcut-style reference links (ones with no reference after them, such as `[link]`). This PR fixes that, by making the second set of brackets optional in the regex.

This also adds tests for those and collapsed-style links (`[link][]`).

Note: for whatever reason, the tests won't run for me (even before I added the new ones, so I don't believe it's an issue caused by my changes), so I can't run the tests locally. But since the PR will automatically run them that should work out still.