### PR TITLE
fix CI broken and some other things

### DIFF
--- a/src/print.ts
+++ b/src/print.ts
@@ -4,7 +4,7 @@ import * as fs from "fs";
 import * as path from 'path';
 import { commands, ExtensionContext, TextDocument, Uri, window, workspace } from 'vscode';
 import localize from './localize';
-import { mdEngine } from "./markdownEngine";
+import { mdEngine, extensionBlacklist } from "./markdownEngine";
 import { isMdEditor } from './util';
 
 let thisContext: ExtensionContext;
@@ -221,9 +221,6 @@ function getPreviewSettingStyles(): string {
             }
         </style>`;
 }
-
-// extensions that treat specially
-const extensionBlacklist = new Set<string>(["vscode.markdown-language-features", "yzhang.markdown-all-in-one"]);
 
 async function getPreviewExtensionStyles() {
     var result = "<style>\n"


### PR DESCRIPTION
似乎markdownEngine需要在加载扩展时就被创建（由于被util引用）
而此时，获取其他扩展的contribution的代码并不能正常工作，这些代码需要等待扩展加载完成
如果不对this extension做特殊处理的话，会导致 加载事件-->获取本插件信息-->等待本插件加载完成 这种链条出现，这种等待链导致了其他的一些问题