### PR TITLE
Setting to turn off default CSS files

### DIFF
--- a/package.json
+++ b/package.json
@@ -302,7 +302,6 @@
                     "description": "%config.print.theme%",
                     "scope": "resource"
                 },
-                ,
                 "markdown.extension.print.useDefaultCSS": {
                     "type": "boolean",
                     "default": true,

--- a/package.json
+++ b/package.json
@@ -302,6 +302,12 @@
                     "description": "%config.print.theme%",
                     "scope": "resource"
                 },
+                ,
+                "markdown.extension.print.useDefaultCSS": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "%config.print.useDefaultCSS%"
+                },
                 "markdown.extension.syntax.decorations": {
                     "type": "boolean",
                     "default": true,

--- a/package.json
+++ b/package.json
@@ -302,10 +302,10 @@
                     "description": "%config.print.theme%",
                     "scope": "resource"
                 },
-                "markdown.extension.print.useDefaultCSS": {
+                "markdown.extension.print.includeVscodeStylesheets": {
                     "type": "boolean",
                     "default": true,
-                    "description": "%config.print.useDefaultCSS%"
+                    "description": "%config.print.includeVscodeStylesheets%"
                 },
                 "markdown.extension.syntax.decorations": {
                     "type": "boolean",

--- a/package.nls.json
+++ b/package.nls.json
@@ -38,6 +38,7 @@
     "config.print.onFileSave.description": "Print current document to HTML when file is saved",
     "config.print.validateUrls.description": "Enable/disable URL validation when printing",
     "config.print.theme": "Theme of the exported HTML",
+    "config.print.useDefaultCSS": "Use default external CSS links",
     "config.syntax.decorations.description": "Add syntax decorations",
     "config.syntax.plainTheme.description": "Only take effect when `extension.syntax.decorations` is enabled",
     "config.katex.macros.description": "User-defined KaTeX macros",

--- a/package.nls.json
+++ b/package.nls.json
@@ -38,7 +38,7 @@
     "config.print.onFileSave.description": "Print current document to HTML when file is saved",
     "config.print.validateUrls.description": "Enable/disable URL validation when printing",
     "config.print.theme": "Theme of the exported HTML",
-    "config.print.useDefaultCSS": "Use default external CSS links",
+    "config.print.includeVscodeStylesheets": "Include VSCode's basic Markdown styles so that the exported HTML looks similar as inside VSCode",
     "config.syntax.decorations.description": "Add syntax decorations",
     "config.syntax.plainTheme.description": "Only take effect when `extension.syntax.decorations` is enabled",
     "config.katex.macros.description": "User-defined KaTeX macros",

--- a/src/print.ts
+++ b/src/print.ts
@@ -119,14 +119,14 @@ async function print(type: string) {
     const hasMath = hasMathEnv(doc.getText());
     const extensionStyles = await getPreviewExtensionStyles();
     const extensionScripts = await getPreviewExtensionScripts();
-    const useCSS = config.get<boolean>('print.UseDefaultCSS')
+    const includeVscodeStyles = config.get<boolean>('print.includeVscodeStylesheets')
     const html = `<!DOCTYPE html>
     <html>
     <head>
         <meta charset="UTF-8">
         <title>${title ? title : ''}</title>
         ${extensionStyles}
-        ${getStyles(doc.uri, hasMath, useCSS)}
+        ${getStyles(doc.uri, hasMath, includeVscodeStyles)}
         ${hasMath ? '<script src="https://cdn.jsdelivr.net/npm/katex-copytex@latest/dist/katex-copytex.min.js"></script>' : ''}
         ${extensionScripts}
     </head>
@@ -176,7 +176,7 @@ function readCss(fileName: string) {
     }
 }
 
-function getStyles(uri: Uri, hasMathEnv: boolean, useCSS: boolean) {
+function getStyles(uri: Uri, hasMathEnv: boolean, includeVscodeStyles: boolean) {
     const katexCss = '<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.10.2/dist/katex.min.css" integrity="sha384-yFRtMMDnQtDRO8rLpMIKrtPCD5jdktao2TV19YiZYWMDkUR5GQZR/NOVTdquEx1j" crossorigin="anonymous">';
     const markdownCss = '<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/Microsoft/vscode/extensions/markdown-language-features/media/markdown.css">';
     const highlightCss = '<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/Microsoft/vscode/extensions/markdown-language-features/media/highlight.css">';
@@ -185,12 +185,11 @@ function getStyles(uri: Uri, hasMathEnv: boolean, useCSS: boolean) {
     const baseCssPaths = ['checkbox.css'].map(s => getMediaPath(s));
     const customCssPaths = getCustomStyleSheets(uri);
 
-    return `${hasMathEnv ? katexCss : ''}
-        ${useCSS ? markdownCss : ''}
-        ${useCSS ? highlightCss : ''}
-        ${hasMathEnv ? copyTeXCss : ''}
-        ${useCSS ? baseCssPaths.map(cssSrc => wrapWithStyleTag(cssSrc)).join('\n') : ''}
-        ${useCSS ? getPreviewSettingStyles(): ''}
+    return `${hasMathEnv ? katexCss + '\n' + copyTeXCss : ''}
+        ${includeVscodeStyles
+            ? markdownCss + '\n' + highlightCss + '\n' + getPreviewSettingStyles()
+            : ''}
+        ${baseCssPaths.map(cssSrc => wrapWithStyleTag(cssSrc)).join('\n')}
         ${customCssPaths.map(cssSrc => wrapWithStyleTag(cssSrc)).join('\n')}`;
 }
 

--- a/src/print.ts
+++ b/src/print.ts
@@ -119,13 +119,14 @@ async function print(type: string) {
     const hasMath = hasMathEnv(doc.getText());
     const extensionStyles = await getPreviewExtensionStyles();
     const extensionScripts = await getPreviewExtensionScripts();
+    const useCSS = config.get<boolean>('print.UseDefaultCSS')
     const html = `<!DOCTYPE html>
     <html>
     <head>
         <meta charset="UTF-8">
         <title>${title ? title : ''}</title>
         ${extensionStyles}
-        ${getStyles(doc.uri, hasMath)}
+        ${getStyles(doc.uri, hasMath, useCSS)}
         ${hasMath ? '<script src="https://cdn.jsdelivr.net/npm/katex-copytex@latest/dist/katex-copytex.min.js"></script>' : ''}
         ${extensionScripts}
     </head>
@@ -175,7 +176,7 @@ function readCss(fileName: string) {
     }
 }
 
-function getStyles(uri: Uri, hasMathEnv: boolean) {
+function getStyles(uri: Uri, hasMathEnv: boolean, useCSS: boolean) {
     const katexCss = '<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.10.2/dist/katex.min.css" integrity="sha384-yFRtMMDnQtDRO8rLpMIKrtPCD5jdktao2TV19YiZYWMDkUR5GQZR/NOVTdquEx1j" crossorigin="anonymous">';
     const markdownCss = '<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/Microsoft/vscode/extensions/markdown-language-features/media/markdown.css">';
     const highlightCss = '<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/Microsoft/vscode/extensions/markdown-language-features/media/highlight.css">';
@@ -185,11 +186,11 @@ function getStyles(uri: Uri, hasMathEnv: boolean) {
     const customCssPaths = getCustomStyleSheets(uri);
 
     return `${hasMathEnv ? katexCss : ''}
-        ${markdownCss}
-        ${highlightCss}
+        ${useCSS ? markdownCss : ''}
+        ${useCSS ? highlightCss : ''}
         ${hasMathEnv ? copyTeXCss : ''}
-        ${baseCssPaths.map(cssSrc => wrapWithStyleTag(cssSrc)).join('\n')}
-        ${getPreviewSettingStyles()}
+        ${useCSS ? baseCssPaths.map(cssSrc => wrapWithStyleTag(cssSrc)).join('\n') : ''}
+        ${useCSS ? getPreviewSettingStyles(): ''}
         ${customCssPaths.map(cssSrc => wrapWithStyleTag(cssSrc)).join('\n')}`;
 }
 


### PR DESCRIPTION
Related to issue #673 
* Added "Use Default CSS" configuration param that switches off all non-custom and non-math CSS links in getStyles() function