### PR TITLE
Made file size limit configurable

### DIFF
--- a/package.json
+++ b/package.json
@@ -317,6 +317,11 @@
                     "default": false,
                     "description": "%config.syntax.plainTheme.description%"
                 },
+                "markdown.extension.syntax.textDecorationFileSizeLimit": {
+                    "type": "number",
+                    "default": 50000,
+                    "description": "The size above which we shouldn't attempt to render text decorations"
+                },
                 "markdown.extension.tableFormatter.enabled": {
                     "type": "boolean",
                     "default": true,

--- a/src/util.ts
+++ b/src/util.ts
@@ -52,9 +52,9 @@ export function mathEnvCheck(doc: TextDocument, pos: Position): string {
     }
 }
 
-const sizeLimit = 50000; // ~50 KB
 let fileSizesCache = {}
 export function isFileTooLarge(document: TextDocument): boolean {
+    const sizeLimit = workspace.getConfiguration('markdown.extension.syntax').get<number>('textDecorationFileSizeLimit');
     const filePath = document.uri.fsPath;
     if (!filePath || !fs.existsSync(filePath)) {
         return false;
@@ -103,12 +103,12 @@ export function showChangelog() {
  * Remove Markdown syntax (bold, italic, links etc.) in a heading
  * For example: `_italic_` -> `italic`
  * This function is used before `slugify`
- * 
+ *
  * (Escape syntax like `1.`)
  * 1. md.render(text)
  * 2. textInHtml(text)
  * (Unescape)
- * 
+ *
  * @param text
  */
 export function mdHeadingToPlaintext(text: string) {


### PR DESCRIPTION
I added an option to the extension to allow users to tune the file size limit. It defaults to the current hardcoded value, 50000, but this allows users who accept the risk of a slowdown to tune the limit higher if need be.