### PR TITLE
Allow extension to activate in MDX files

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "license": "MIT",
     "activationEvents": [
         "onLanguage:markdown",
+        "onLanguage:mdx",
         "workspaceContains:README.md"
     ],
     "main": "./dist/extension",
@@ -90,122 +91,144 @@
                 "command": "markdown.extension.editing.toggleBold",
                 "key": "ctrl+b",
                 "mac": "cmd+b",
-                "when": "editorTextFocus && !editorReadonly && editorLangId == markdown"
+                "when": "editorTextFocus && !editorReadonly",
+                "injectTo": ["text.html.markdown.jsx", "text.html.markdown"]
             },
             {
                 "command": "markdown.extension.editing.toggleItalic",
                 "key": "ctrl+i",
                 "mac": "cmd+i",
-                "when": "editorTextFocus && !editorReadonly && editorLangId == markdown"
+                "when": "editorTextFocus && !editorReadonly",
+                "injectTo": ["text.html.markdown.jsx", "text.html.markdown"]
             },
             {
                 "command": "markdown.extension.editing.toggleStrikethrough",
                 "key": "alt+s",
-                "when": "editorTextFocus && !editorReadonly && editorLangId == markdown && !isMac"
+                "when": "editorTextFocus && !editorReadonly && !isMac",
+                "injectTo": ["text.html.markdown.jsx", "text.html.markdown"]
             },
             {
                 "command": "markdown.extension.editing.toggleHeadingUp",
                 "key": "ctrl+shift+]",
                 "mac": "ctrl+shift+]",
-                "when": "editorTextFocus && !editorReadonly && editorLangId == markdown"
+                "when": "editorTextFocus && !editorReadonly",
+                "injectTo": ["text.html.markdown.jsx", "text.html.markdown"]
             },
             {
                 "command": "markdown.extension.editing.toggleHeadingDown",
                 "key": "ctrl+shift+[",
                 "mac": "ctrl+shift+[",
-                "when": "editorTextFocus && !editorReadonly && editorLangId == markdown"
+                "when": "editorTextFocus && !editorReadonly",
+                "injectTo": ["text.html.markdown.jsx", "text.html.markdown"]
             },
             {
                 "command": "markdown.extension.editing.toggleMath",
                 "key": "ctrl+m",
                 "mac": "cmd+m",
-                "when": "editorTextFocus && !editorReadonly && editorLangId == markdown"
+                "when": "editorTextFocus && !editorReadonly",
+                "injectTo": ["text.html.markdown.jsx", "text.html.markdown"]
             },
             {
                 "command": "markdown.extension.onEnterKey",
                 "key": "enter",
-                "when": "editorTextFocus && !editorReadonly && editorLangId == markdown && !suggestWidgetVisible && vim.mode != 'Normal' && vim.mode != 'Visual' && vim.mode != 'VisualBlock' && vim.mode != 'VisualLine' && vim.mode != 'SearchInProgressMode' && vim.mode != 'CommandlineInProgress' && vim.mode != 'Replace' && vim.mode != 'EasyMotionMode' && vim.mode != 'EasyMotionInputMode' && vim.mode != 'SurroundInputMode'"
+                "when": "editorTextFocus && !editorReadonly && !suggestWidgetVisible && vim.mode != 'Normal' && vim.mode != 'Visual' && vim.mode != 'VisualBlock' && vim.mode != 'VisualLine' && vim.mode != 'SearchInProgressMode' && vim.mode != 'CommandlineInProgress' && vim.mode != 'Replace' && vim.mode != 'EasyMotionMode' && vim.mode != 'EasyMotionInputMode' && vim.mode != 'SurroundInputMode'",
+                "injectTo": ["text.html.markdown.jsx", "text.html.markdown"]
             },
             {
                 "command": "markdown.extension.onCtrlEnterKey",
                 "key": "ctrl+enter",
                 "mac": "cmd+enter",
-                "when": "editorTextFocus && !editorReadonly && editorLangId == markdown && !suggestWidgetVisible"
+                "when": "editorTextFocus && !editorReadonly && !suggestWidgetVisible",
+                "injectTo": ["text.html.markdown.jsx", "text.html.markdown"]
             },
             {
                 "command": "markdown.extension.onShiftEnterKey",
                 "key": "shift+enter",
-                "when": "editorTextFocus && !editorReadonly && editorLangId == markdown && !suggestWidgetVisible"
+                "when": "editorTextFocus && !editorReadonly && !suggestWidgetVisible",
+                "injectTo": ["text.html.markdown.jsx", "text.html.markdown"]
             },
             {
                 "command": "markdown.extension.onTabKey",
                 "key": "tab",
-                "when": "editorTextFocus && !editorReadonly && editorLangId == markdown && !suggestWidgetVisible && !editorTabMovesFocus && !inSnippetMode && !hasSnippetCompletions && !hasOtherSuggestions"
+                "when": "editorTextFocus && !editorReadonly && !suggestWidgetVisible && !editorTabMovesFocus && !inSnippetMode && !hasSnippetCompletions && !hasOtherSuggestions",
+                "injectTo": ["text.html.markdown.jsx", "text.html.markdown"]
             },
             {
                 "command": "markdown.extension.onShiftTabKey",
                 "key": "shift+tab",
-                "when": "editorTextFocus && !editorReadonly && editorLangId == markdown && !suggestWidgetVisible && !editorTabMovesFocus && !inSnippetMode && !hasSnippetCompletions && !hasOtherSuggestions"
+                "when": "editorTextFocus && !editorReadonly  && !suggestWidgetVisible && !editorTabMovesFocus && !inSnippetMode && !hasSnippetCompletions && !hasOtherSuggestions",
+                "injectTo": ["text.html.markdown.jsx", "text.html.markdown"]
             },
             {
                 "command": "markdown.extension.onBackspaceKey",
                 "key": "backspace",
-                "when": "editorTextFocus && !editorReadonly && editorLangId == markdown && !suggestWidgetVisible && vim.mode != 'Normal' && vim.mode != 'Visual' && vim.mode != 'VisualBlock' && vim.mode != 'VisualLine' && vim.mode != 'SearchInProgressMode' && vim.mode != 'CommandlineInProgress' && vim.mode != 'Replace' && vim.mode != 'EasyMotionMode' && vim.mode != 'EasyMotionInputMode' && vim.mode != 'SurroundInputMode'"
+                "when": "editorTextFocus && !editorReadonly  && !suggestWidgetVisible && vim.mode != 'Normal' && vim.mode != 'Visual' && vim.mode != 'VisualBlock' && vim.mode != 'VisualLine' && vim.mode != 'SearchInProgressMode' && vim.mode != 'CommandlineInProgress' && vim.mode != 'Replace' && vim.mode != 'EasyMotionMode' && vim.mode != 'EasyMotionInputMode' && vim.mode != 'SurroundInputMode'",
+                "injectTo": ["text.html.markdown.jsx", "text.html.markdown"]
             },
             {
                 "command": "markdown.extension.onMoveLineUp",
                 "key": "alt+up",
-                "when": "editorTextFocus && !editorReadonly && editorLangId == markdown && !suggestWidgetVisible"
+                "when": "editorTextFocus && !editorReadonly  && !suggestWidgetVisible",
+                "injectTo": ["text.html.markdown.jsx", "text.html.markdown"]
             },
             {
                 "command": "markdown.extension.onMoveLineDown",
                 "key": "alt+down",
-                "when": "editorTextFocus && !editorReadonly && editorLangId == markdown && !suggestWidgetVisible"
+                "when": "editorTextFocus && !editorReadonly  && !suggestWidgetVisible",
+                "injectTo": ["text.html.markdown.jsx", "text.html.markdown"]
             },
             {
                 "command": "markdown.extension.onCopyLineUp",
                 "key": "shift+alt+up",
-                "when": "editorTextFocus && !editorReadonly && editorLangId == markdown && !suggestWidgetVisible"
+                "when": "editorTextFocus && !editorReadonly  && !suggestWidgetVisible",
+                "injectTo": ["text.html.markdown.jsx", "text.html.markdown"]
             },
             {
                 "command": "markdown.extension.onCopyLineDown",
                 "key": "shift+alt+down",
-                "when": "editorTextFocus && !editorReadonly && editorLangId == markdown && !suggestWidgetVisible"
+                "when": "editorTextFocus && !editorReadonly  && !suggestWidgetVisible",
+                "injectTo": ["text.html.markdown.jsx", "text.html.markdown"]
             },
             {
                 "command": "markdown.extension.onIndentLines",
                 "key": "ctrl+]",
                 "mac": "cmd+]",
-                "when": "editorTextFocus && editorLangId == markdown && !suggestWidgetVisible"
+                "when": "editorTextFocus  && !suggestWidgetVisible",
+                "injectTo": ["text.html.markdown.jsx", "text.html.markdown"]
             },
             {
                 "command": "markdown.extension.onOutdentLines",
                 "key": "ctrl+[",
                 "mac": "cmd+[",
-                "when": "editorTextFocus && editorLangId == markdown && !suggestWidgetVisible"
+                "when": "editorTextFocus  && !suggestWidgetVisible",
+                "injectTo": ["text.html.markdown.jsx", "text.html.markdown"]
             },
             {
                 "command": "markdown.extension.checkTaskList",
                 "key": "alt+c",
-                "when": "editorTextFocus && editorLangId == markdown"
+                "when": "editorTextFocus",
+                "injectTo": ["text.html.markdown.jsx", "text.html.markdown"]
             },
             {
                 "command": "markdown.extension.togglePreview",
                 "key": "ctrl+shift+v",
                 "mac": "cmd+shift+v",
-                "when": "!terminalFocus"
+                "when": "!terminalFocus",
+                "injectTo": ["text.html.markdown.jsx", "text.html.markdown"]
             },
             {
                 "command": "markdown.extension.togglePreviewToSide",
                 "key": "ctrl+k v",
                 "mac": "cmd+k v",
-                "when": "!terminalFocus"
+                "when": "!terminalFocus",
+                "injectTo": ["text.html.markdown.jsx", "text.html.markdown"]
             },
             {
                 "command": "markdown.extension.editing.paste",
                 "key": "ctrl+v",
                 "mac": "cmd+v",
-                "when": "editorTextFocus && editorLangId == markdown && editorHasSelection"
+                "when": "editorTextFocus  && editorHasSelection",
+                "injectTo": ["text.html.markdown.jsx", "text.html.markdown"]
             }
         ],
         "configuration": {
@@ -389,7 +412,7 @@
                 }
             }
         },
-        "markdown.markdownItPlugins": true,
+        "markdown.markdownItPlugins": true, 
         "markdown.previewStyles": [
             "./media/checkbox.css",
             "./node_modules/katex/dist/katex.min.css"
@@ -399,19 +422,25 @@
                 "scopeName": "markdown.math_display",
                 "path": "./syntaxes/math_display.markdown.tmLanguage.json",
                 "injectTo": [
-                    "text.html.markdown"
+                    "text.html.markdown",
+                    "text.html.markdown.jsx"
                 ]
             },
             {
                 "scopeName": "markdown.math_inline",
                 "path": "./syntaxes/math_inline.markdown.tmLanguage.json",
                 "injectTo": [
-                    "text.html.markdown"
+                    "text.html.markdown",
+                    "text.html.markdown.jsx"
                 ]
             },
             {
                 "scopeName": "text.katex",
-                "path": "./syntaxes/katex.tmLanguage.json"
+                "path": "./syntaxes/katex.tmLanguage.json",
+                "injectTo": [
+                    "text.html.markdown",
+                    "text.html.markdown.jsx"
+                ]
             }
         ]
     },

--- a/package.json
+++ b/package.json
@@ -412,7 +412,7 @@
                 }
             }
         },
-        "markdown.markdownItPlugins": true, 
+        "markdown.markdownItPlugins": true,
         "markdown.previewStyles": [
             "./media/checkbox.css",
             "./node_modules/katex/dist/katex.min.css"

--- a/package.nls.ja.json
+++ b/package.nls.ja.json
@@ -41,6 +41,7 @@
     "showMe": "表示する",
     "dismiss": "却下",
     "noValidMarkdownFile": "有効なMarkdownファイルがありません",
+    "warnMDXFileConvert": "Warning: MDX Files won't be properly converted, unless they only contain Markdown.",
     "printing": "出力中",
     "to": "へ",
     "unableToReadFile": "ファイルを読み取れません",

--- a/package.nls.json
+++ b/package.nls.json
@@ -48,6 +48,7 @@
     "showMe": "Show Me",
     "dismiss": "Dismiss",
     "noValidMarkdownFile": "No valid Markdown file",
+    "warnMDXFileConvert": "Warning: MDX Files won't be properly converted, unless they only contain Markdown.",
     "printing": "Printing",
     "to": "to",
     "unableToReadFile": "Unable to read file",

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -40,6 +40,7 @@
     "showMe": "显示更新日志",
     "dismiss": "忽略",
     "noValidMarkdownFile": "未选中有效的 Markdown 文件",
+    "warnMDXFileConvert": "Warning: MDX Files won't be properly converted, unless they only contain Markdown.",
     "printing": "将",
     "to": "打印到",
     "unableToReadFile": "无法读取文件",

--- a/src/print.ts
+++ b/src/print.ts
@@ -115,8 +115,8 @@ async function print(type: string, uri?: Uri, outFolder?: string) {
     //// Convert `.md` links to `.html` by default (#667)
     const hrefRegex = /(<a[^>]+href=")([^"]+)("[^>]*>)/g;  // Match '<a...href="..."...>'
     body = body.replace(hrefRegex, function (_, g1, g2, g3) {
-        if (g2.endsWith('.md')) {
-            return `${g1}${g2.replace(/\.md$/, '.html')}${g3}`;
+        if (g2.endsWith('.md') || g2.endsWith('.mdx')) {
+            return `${g1}${g2.replace(/\.mdx?$/, '.html')}${g3}`;
         } else {
             return _;
         }

--- a/src/print.ts
+++ b/src/print.ts
@@ -37,6 +37,10 @@ async function print(type: string, uri?: Uri, outFolder?: string) {
         return;
     }
 
+    if (editor.document.languageId === 'mdx') {
+        window.showWarningMessage(localize("warnMDXFileConvert"));
+    }
+
     const doc = uri ? await workspace.openTextDocument(uri) : editor.document;
     if (doc.isDirty || doc.isUntitled) {
         doc.save();

--- a/src/util.ts
+++ b/src/util.ts
@@ -10,10 +10,10 @@ import { mdEngine } from './markdownEngine';
    └────────┘ */
 
 /** Scheme `File` or `Untitled` */
-export const mdDocSelector = [{ language: 'markdown', scheme: 'file' }, { language: 'markdown', scheme: 'untitled' }];
+export const mdDocSelector = [{ language: 'markdown', scheme: 'file' }, { language: 'markdown', scheme: 'untitled' }, { language: 'mdx', scheme: 'file' }, { language: 'mdx', scheme: 'file' }];
 
 export function isMdEditor(editor: TextEditor) {
-    return editor && editor.document && editor.document.languageId === 'markdown';
+    return editor && editor.document && (editor.document.languageId === 'mdx' || editor.document.languageId === 'markdown');
 }
 
 export const REGEX_FENCED_CODE_BLOCK = /^( {0,3}|\t)```[^`\r\n]*$[\w\W]+?^( {0,3}|\t)``` *$/gm;


### PR DESCRIPTION
Allows for the extension to work within MDX files.

Caveat: The "Print current page to HTML" command won't properly convert MDX into HTML; It will treat the document as markdown.