### PR TITLE
Add gitea slugification

### DIFF
--- a/package.json
+++ b/package.json
@@ -371,6 +371,7 @@
                     "enum": [
                         "github",
                         "gitlab",
+                        "gitea",
                         "vscode"
                     ],
                     "description": "%config.toc.slugifyMode.description%"

--- a/src/test/suite/slugify.test.ts
+++ b/src/test/suite/slugify.test.ts
@@ -29,18 +29,19 @@ suite("Slugify function.", () => {
         "Via [remark-cli][]": "via-remark-cli",
         "1. not a list": "1-not-a-list",
         "1) not a list": "1-not-a-list",
-        ":foo_foo: foo": "foo-foo-foo"
+        "foo & < >  \"foo\"": "foo-foo",
+        "1": "anchor-1" // GitLab adds "anchor-" before digit-only IDs
     }
 
     const headings_gitea = {
         "foo _italic_ bar": "foo-italic-bar",
-        "foo_foo_bar": "foo_foo_bar",
+        "foo_foo_bar": "foo-foo-bar",
         "`a.b` c": "ab-c",
         "Via [remark-cli][]": "via-remark-cli",
         "1. not a list": "1-not-a-list",
         "1) not a list": "1-not-a-list",
-        "foo & < >  \"foo\"": "foo-foo",
-        "1": "anchor-1" // GitLab adds "anchor-" before digit-only IDs
+        "foo & < >  \"foo\"": "foo---foo",
+        "$\\LaTeX equations$": "latex-equations"
     }
 
     for (const heading of Object.keys(headings)) {
@@ -65,7 +66,7 @@ suite("Slugify function.", () => {
     }
 
     for (const heading of Object.keys(headings_gitea)) {
-        const slug = headings_gitlab[heading];
+        const slug = headings_gitea[heading];
         test(`(Gitea) ${heading} → ${slug}`, () => {
             assert.strictEqual(util.slugify(heading, "gitea"), slug);
         });

--- a/src/test/suite/slugify.test.ts
+++ b/src/test/suite/slugify.test.ts
@@ -29,6 +29,16 @@ suite("Slugify function.", () => {
         "Via [remark-cli][]": "via-remark-cli",
         "1. not a list": "1-not-a-list",
         "1) not a list": "1-not-a-list",
+        ":foo_foo: foo": "foo-foo-foo"
+    }
+
+    const headings_gitea = {
+        "foo _italic_ bar": "foo-italic-bar",
+        "foo_foo_bar": "foo_foo_bar",
+        "`a.b` c": "ab-c",
+        "Via [remark-cli][]": "via-remark-cli",
+        "1. not a list": "1-not-a-list",
+        "1) not a list": "1-not-a-list",
         "foo & < >  \"foo\"": "foo-foo",
         "1": "anchor-1" // GitLab adds "anchor-" before digit-only IDs
     }
@@ -51,6 +61,13 @@ suite("Slugify function.", () => {
         const slug = headings_gitlab[heading];
         test(`(GitLab) ${heading} → ${slug}`, () => {
             assert.strictEqual(util.slugify(heading, "gitlab"), slug);
+        });
+    }
+
+    for (const heading of Object.keys(headings_gitea)) {
+        const slug = headings_gitlab[heading];
+        test(`(Gitea) ${heading} → ${slug}`, () => {
+            assert.strictEqual(util.slugify(heading, "gitea"), slug);
         });
     }
 });

--- a/src/test/suite/toc.test.ts
+++ b/src/test/suite/toc.test.ts
@@ -308,6 +308,30 @@ suite("TOC.", () => {
             new Selection(5, 28, 5, 28)).then(done, done);
     });
 
+    test("Non-Latin symbols (Option `toc.slugifyMode = gitea`)", done => {
+        testCommand('markdown.extension.toc.create',
+            {
+                "markdown.extension.toc.slugifyMode": "gitea"
+            },
+            [
+                '# Секция 1',
+                '',
+                '## Секция 1.1',
+                '',
+                ''
+            ],
+            new Selection(4, 0, 4, 0),
+            [
+                '# Секция 1',
+                '',
+                '## Секция 1.1',
+                '',
+                '- [Секция 1](#секция-1)',
+                '  - [Секция 1.1](#секция-11)'
+            ],
+            new Selection(5, 28, 5, 28)).then(done, done);
+    });
+
     test("Update multiple TOCs", done => {
         testCommand('markdown.extension.toc.update',
             {

--- a/src/util.ts
+++ b/src/util.ts
@@ -181,6 +181,15 @@ export function slugify(heading: string, mode?: string, downcase?: boolean) {
         if (downcase) {
             slug = slug.toLowerCase()
         }
+    } else if (mode === 'gitea') {
+        // Gitea slugify function still to be found
+        slug = slug.replace(PUNCTUATION_REGEXP, '')
+            .replace(/ /g, '-')
+            .replace(/_/g, '-');
+
+        if (downcase) {
+            slug = slug.toLowerCase()
+        }
     } else if (mode === 'gitlab') {
         // GitLab slugify function, translated to JS
         // <https://gitlab.com/gitlab-org/gitlab/blob/master/lib/banzai/filter/table_of_contents_filter.rb#L32>


### PR DESCRIPTION
When generating TOC, the links are not properly slugified for Gitea. One of the issues I had was that Gitea expect all underscores to be hyphen.

**This is a quick hack, I'm still missing the source for the slugification function of Gitea so I'm not sure all the proper changes are made when slugifying. Also the tests probably doesn't cover every cases.**