### PR TITLE
Fix for togglePreviewToSide

### DIFF
--- a/package.json
+++ b/package.json
@@ -197,10 +197,10 @@
                 "when": "!terminalFocus"
             },
             {
-                "command": "markdown.extension.togglePreviewToSide",
+                "command": "markdown.extension.closePreviewToSide",
                 "key": "ctrl+k v",
                 "mac": "cmd+k v",
-                "when": "!terminalFocus"
+                "when": "markdownPreviewFocus"
             },
             {
                 "command": "markdown.extension.editing.paste",

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -25,13 +25,8 @@ export function activate(context: ExtensionContext) {
                 commands.executeCommand('markdown.showPreview');
             }
         }),
-        commands.registerCommand('markdown.extension.togglePreviewToSide', () => {
-            let editor = window.activeTextEditor;
-            if (!editor) {
-                commands.executeCommand('workbench.action.closeActiveEditor');
-            } else if (editor.document.languageId === 'markdown') {
-                commands.executeCommand('markdown.showPreviewToSide');
-            }
+        commands.registerCommand('markdown.extension.closePreviewToSide', () => {
+            commands.executeCommand('workbench.action.closeActiveEditor');
         })
     );
 }


### PR DESCRIPTION
Changes togglePreviewToSide to closePreviewToSide. Opening preview to side is handled by VScode. As long as they have the same key binding, it will behave like toggle.

Cheking for `window.activeTextEditor` is not working becase acording to API documentation it returns:

> "The currently active editor or undefined. The active editor is the one that currently has focus or, when none has focus, the one that has changed input most recently."

Since "one that has changed input most recently" will always be text editor in the current window, when preview opened to the side,
`activeTextEditor` will almost never be undefined.

When markdown preview has focus it sets the context `markdownPreviewFocus`. Since there no way of getting contexts from the
extension code like described here https://github.com/microsoft/vscode/issues/46445#issuecomment-377591247 I think it's better to change toggle to close and check for `markdownPreviewFocus` from key bindings.

Fixes #778 