### PR TITLE
Don't treat ATX headings with following thematic breaks as setext headings

### DIFF
--- a/src/test/suite/toc.test.ts
+++ b/src/test/suite/toc.test.ts
@@ -296,6 +296,24 @@ suite("TOC.", () => {
             new Selection(16, 15, 16, 15)).then(done, done);
     });
 
+    test("ATX Heading followed by thematic break doesn't get parsed as a setext heading", done => {
+        testCommand('markdown.extension.toc.create', {},
+            [
+                '# H1',
+                '---',
+                '',
+                '',
+            ],
+            new Selection(3, 0, 3, 0),
+            [
+                '# H1',
+                '---',
+                '',
+                '- [H1](#h1)',
+            ],
+            new Selection(3, 10, 3, 10)).then(done, done);
+    });
+
     test("Non-Latin symbols (Option `toc.slugifyMode: github`)", done => {
         testCommand('markdown.extension.toc.create',
             {

--- a/src/toc.ts
+++ b/src/toc.ts
@@ -319,6 +319,12 @@ function onWillSave(e: TextDocumentWillSaveEvent) {
     }
 }
 
+function isAtxHeading(lineText: String): Boolean {
+    return lineText.trim().startsWith('#')
+        && !lineText.startsWith('    ')  //// The opening `#` character may be indented 0-3 spaces
+        && lineText.includes('# ')
+}
+
 /**
  * Updates `tocConfig` and `docConfig`.
  * @param editor The editor, from which we detect `docConfig`.
@@ -370,6 +376,7 @@ export function buildToc(doc: TextDocument): IHeading[] {
         //// Transform setext headings to ATX headings
         if (
             i < arr.length - 1
+            && !isAtxHeading(lineText) //// #879
             && lineText.match(/^ {0,3}\S.*$/)
             && lineText.replace(/[ -]/g, '').length > 0  //// #629
             && arr[i + 1].match(/^ {0,3}(=+|-{2,}) *$/)
@@ -387,9 +394,7 @@ export function buildToc(doc: TextDocument): IHeading[] {
 
     const toc = lines.map((lineText, index) => {
         if (
-            lineText.trim().startsWith('#')
-            && !lineText.startsWith('    ')  //// The opening `#` character may be indented 0-3 spaces
-            && lineText.includes('# ')
+            isAtxHeading(lineText)
             && !lineText.includes('&lt; omit in toc &gt;')
         ) {
             lineText = lineText.replace(/^ +/, '');


### PR DESCRIPTION
Fixes #879 