### PR TITLE
Fix contributed scripts load position and option

### DIFF
--- a/src/print.ts
+++ b/src/print.ts
@@ -151,11 +151,11 @@ async function print(type: string, uri?: Uri, outFolder?: string) {
         <title>${title ? encodeHTML(title) : ''}</title>
         ${extensionStyles}
         ${getStyles(doc.uri, hasMath, includeVscodeStyles)}
-        ${hasMath ? '<script src="https://cdn.jsdelivr.net/npm/katex-copytex@latest/dist/katex-copytex.min.js"></script>' : ''}
-        ${extensionScripts}
     </head>
     <body class="vscode-body${config.get<string>('print.theme') === 'light' ? ' vscode-light' : ''}">
         ${body}
+        ${hasMath ? '<script async src="https://cdn.jsdelivr.net/npm/katex-copytex@latest/dist/katex-copytex.min.js"></script>' : ''}
+        ${extensionScripts}
     </body>
     </html>`;
 
@@ -322,7 +322,7 @@ async function getPreviewExtensionScripts() {
             continue;
         }
         for (const scriptFile of contribute.previewScripts) {
-            result += `<script type="text/javascript">\n/* From extension ${contribute.extensionId} */\n`;
+            result += `<script async type="text/javascript">\n/* From extension ${contribute.extensionId} */\n`;
             try {
                 result += await fs.promises.readFile(scriptFile.fsPath, { encoding: "utf8" });
             } catch (error) {


### PR DESCRIPTION
This PR fixes contributed scripts load position and option to just like VSCode's `markdown preivew`.

VSCode's `markdown preivew` load extension contributed scripts asynchronously and after the rest of the document : 
https://github.com/microsoft/vscode/blob/c5dc9d16be5cbd18b4a1bc44941ef8a1b16cf983/extensions/markdown-language-features/src/features/previewContentProvider.ts#L94