### PR TITLE
Add print.enableCheckBoxes config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ All you need for Markdown (keyboard shortcuts, table of contents, auto preview a
 - [FAQ](#faq)
     - [Q: Error "command 'markdown.extension.onXXXKey' not found"](#q-error-command-markdownextensiononxxxkey-not-found)
     - [Q: Which Markdown syntax is supported?](#q-which-markdown-syntax-is-supported)
-    - [Q: This extension has overridden some of my key bindings (e.g. <kbd>Ctrl</kbd> + <kbd>B</kbd>, <kbd>Alt</kbd> + <kbd>C</kbd>)](#q-this-extension-has-overridden-some-of-my-key-bindings-eg-ctrl--b-alt--c)
+    - [Q: This extension has overridden some of my key bindings (e.g. Ctrl + B, Alt + C)](#q-this-extension-has-overridden-some-of-my-key-bindings-eg-ctrl--b-alt--c)
     - [Q: The extension is unresponsive, causing lag etc. (performance issues)](#q-the-extension-is-unresponsive-causing-lag-etc-performance-issues)
 - [Changelog](#changelog)
 - [Latest Development Build](#latest-development-build)
@@ -219,6 +219,7 @@ Tip: also support the option `completion.root`
 | `markdown.extension.print.onFileSave`                      | `false`    | Print to HTML on file save                                                                       |
 | `markdown.extension.print.theme`                           | `light`    | Theme of the exported HTML                                                                       |
 | `markdown.extension.print.validateUrls`                    | `true`     | Enable/disable URL validation when printing                                                      |
+| `markdown.extension.print.enableCheckBoxes`                | `false`    | Enable/disable The checkboxes of task lists                                                      |
 | `markdown.extension.syntax.decorations`                    | `true`     | Add decorations to ~~strikethrough~~ and `code span`                                             |
 | `markdown.extension.syntax.decorationFileSizeLimit`        | 50000      | Don't render syntax decorations if a file is larger than this size (in byte/B)                   |
 | `markdown.extension.syntax.plainTheme`                     | `false`    | A distraction-free theme                                                                         |

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ All you need for Markdown (keyboard shortcuts, table of contents, auto preview a
 - [FAQ](#faq)
     - [Q: Error "command 'markdown.extension.onXXXKey' not found"](#q-error-command-markdownextensiononxxxkey-not-found)
     - [Q: Which Markdown syntax is supported?](#q-which-markdown-syntax-is-supported)
-    - [Q: This extension has overridden some of my key bindings (e.g. Ctrl + B, Alt + C)](#q-this-extension-has-overridden-some-of-my-key-bindings-eg-ctrl--b-alt--c)
+    - [Q: This extension has overridden some of my key bindings (e.g. <kbd>Ctrl</kbd> + <kbd>B</kbd>, <kbd>Alt</kbd> + <kbd>C</kbd>)](#q-this-extension-has-overridden-some-of-my-key-bindings-eg-ctrl--b-alt--c)
     - [Q: The extension is unresponsive, causing lag etc. (performance issues)](#q-the-extension-is-unresponsive-causing-lag-etc-performance-issues)
 - [Changelog](#changelog)
 - [Latest Development Build](#latest-development-build)

--- a/package.json
+++ b/package.json
@@ -331,6 +331,11 @@
                     "default": true,
                     "description": "%config.print.includeVscodeStylesheets%"
                 },
+                "markdown.extension.print.enableCheckBoxes": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "%config.print.enableCheckBoxes%"
+                },
                 "markdown.extension.print.onFileSave": {
                     "type": "boolean",
                     "default": false,

--- a/package.nls.json
+++ b/package.nls.json
@@ -29,6 +29,7 @@
     "config.print.absoluteImgPath.description": "Convert image path to absolute path.",
     "config.print.imgToBase64.description": "Convert images to base64 when printing to HTML.",
     "config.print.includeVscodeStylesheets": "Include VS Code's basic Markdown styles so that the exported HTML looks similar as inside VS Code.",
+    "config.print.enableCheckBoxes": "Enable checkboxes in the exported HTML.",
     "config.print.onFileSave.description": "Print current document to HTML when file is saved.",
     "config.print.theme": "Theme of the exported HTML. Only affects code blocks.",
     "config.print.validateUrls.description": "Enable/disable URL validation when printing.",

--- a/src/configuration/KnownKey.ts
+++ b/src/configuration/KnownKey.ts
@@ -17,6 +17,7 @@ type KnownKey =
     | "print.absoluteImgPath"
     | "print.imgToBase64"
     | "print.includeVscodeStylesheets"
+    | "print.enableCheckBoxes"
     | "print.onFileSave"
     | "print.theme"
     | "print.validateUrls"

--- a/src/markdownEngine.ts
+++ b/src/markdownEngine.ts
@@ -223,6 +223,10 @@ class MarkdownEngine implements IDynamicMarkdownEngine {
             katexOptions['macros'] = userMacros;
         }
 
+        let taskListOptions = {
+            enabled: vscode.workspace.getConfiguration('markdown.extension.print').get<boolean>('enableCheckBoxes', false)
+        };
+
         md = new MarkdownIt({
             html: true,
             highlight: (str: string, lang?: string) => {
@@ -238,7 +242,7 @@ class MarkdownEngine implements IDynamicMarkdownEngine {
 
         // contributions provided by this extension must be processed specially,
         // since this extension may not finish activing when a engine is needed to be created.
-        md.use(mdtl).use(mdkt, katexOptions);
+        md.use(mdtl, taskListOptions).use(mdkt, katexOptions);
 
         if (!vscode.workspace.getConfiguration('markdown.extension.print').get<boolean>('validateUrls', true)) {
             md.validateLink = () => true;


### PR DESCRIPTION
Fix #774

This option enables the checkboxes in the outputted HTML, useful for making to-do lists