### PR TITLE
Added bold indicator configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ Tip: also support the option `completion.root`
 | `markdown.extension.completion.respectVscodeSearchExclude` | `true`     | Whether to consider `search.exclude` option when providing file path completions                 |
 | `markdown.extension.completion.root`                       |            | Root folder when providing file path completions (It takes effect when the path starts with `/`) |
 | `markdown.extension.italic.indicator`                      | `*`        | Use `*` or `_` to wrap italic text                                                               |
+| `markdown.extension.bold.indicator`                        | `**`       | Use `**` or `__` to wrap bold text                                                               |
 | `markdown.extension.katex.macros`                          | `{}`       | KaTeX macros e.g. `{ "\\name": "expansion", ... }`                                               |
 | `markdown.extension.list.indentationSize`                  | `adaptive` | Use different indentation size for ordered and unordered list                                    |
 | `markdown.extension.orderedList.autoRenumber`              | `true`     | Auto fix list markers as you edits                                                               |

--- a/package.json
+++ b/package.json
@@ -289,6 +289,15 @@
                         "_"
                     ]
                 },
+                "markdown.extension.bold.indicator": {
+                    "type": "string",
+                    "default": "**",
+                    "markdownDescription": "%config.bold.indicator.description%",
+                    "enum": [
+                        "**",
+                        "__"
+                    ]
+                },
                 "markdown.extension.katex.macros": {
                     "type": "object",
                     "default": {},

--- a/package.nls.json
+++ b/package.nls.json
@@ -16,6 +16,7 @@
     "config.completion.respectVscodeSearchExclude": "Whether to exclude files from auto-completion using VS Code's `#search.exclude#` setting. (`node_modules`, `bower_components` and `*.code-search` are **always excluded**, not affected by this option.)",
     "config.completion.root": "The root folder for path auto-completion.",
     "config.italic.indicator.description": "Use `*` or `_` to wrap italic text.",
+    "config.bold.indicator.description": "Use `**` or `__` to wrap bold text.",
     "config.katex.macros.description": "User-defined KaTeX macros.",
     "config.list.indentationSize.description": "List indentation scheme. (Also affects TOC generation.)\n\nWhether to use different indentation sizes on different list contexts or stick to VS Code's tab size.",
     "config.list.indentationSize.enumDescriptions.adaptive": "Adaptive indentation size according to the context, trying to **left align the sublist with its parent's content**. For example:\n\n```markdown\n- Parent\n  - Sublist\n\n1. Parent\n   1. Sublist\n\n10. Parent with longer marker\n    1. Sublist\n```",

--- a/src/configuration/model.ts
+++ b/src/configuration/model.ts
@@ -1,4 +1,4 @@
-import type { MarkdownBulletListMarker, MarkdownEmphasisIndicator } from "../contract/MarkdownSpec";
+import type { MarkdownBulletListMarker, MarkdownEmphasisIndicator, MarkdownStrongIndicator } from "../contract/MarkdownSpec";
 import type { SlugifyMode } from "../contract/SlugifyMode";
 
 /**
@@ -11,6 +11,7 @@ export interface IConfigurationKeyTypeMap {
     "completion.root": string;
 
     "italic.indicator": MarkdownEmphasisIndicator;
+    "bold.indicator": MarkdownStrongIndicator;
 
     /**
      * A collection of custom macros.

--- a/src/contract/MarkdownSpec.ts
+++ b/src/contract/MarkdownSpec.ts
@@ -22,6 +22,15 @@ export const enum MarkdownEmphasisIndicator {
 }
 
 /**
+ * CommonMark strong emphasis indicator.
+ * https://spec.commonmark.org/0.29/#emphasis-and-strong-emphasis
+ */
+ export const enum MarkdownStrongIndicator {
+    DoubleAsterisk = "**",
+    DoubleUnderscore = "__",
+}
+
+/**
  * The heading level allowed by the CommonMark Spec.
  * https://spec.commonmark.org/0.29/#atx-headings
  */

--- a/src/formatting.ts
+++ b/src/formatting.ts
@@ -28,7 +28,8 @@ const singleLinkRegex: RegExp = createLinkRegex();
 // Return Promise because need to chain operations in unit tests
 
 function toggleBold() {
-    return styleByWrapping('**');
+    let indicator = workspace.getConfiguration('markdown.extension.bold').get<string>('indicator');
+    return styleByWrapping(indicator);
 }
 
 function toggleItalic() {

--- a/src/syntaxDecorations.ts
+++ b/src/syntaxDecorations.ts
@@ -65,6 +65,11 @@ const regexDecorTypeMappingPlainTheme: ReadonlyArray<[RegExp, ReadonlyArray<Deco
         /(\*\*)([^\*\`\!\@\#\%\^\&\(\)\-\=\+\[\{\]\}\\\|\;\:\'\"\,\.\<\>\/\?\s].*?[^\*\`\!\@\#\%\^\&\(\)\-\=\+\[\{\]\}\\\|\;\:\'\"\,\.\<\>\/\?\s])(\*\*)/,
         [DecorationType.gray, DecorationType.baseColor, DecorationType.gray]
     ],
+    // __bold__
+    [
+        /(__)([^\*\`\!\@\#\%\^\&\(\)\-\=\+\[\{\]\}\\\|\;\:\'\"\,\.\<\>\/\?\s].*?[^\*\`\!\@\#\%\^\&\(\)\-\=\+\[\{\]\}\\\|\;\:\'\"\,\.\<\>\/\?\s])(__)/,
+        [DecorationType.gray, DecorationType.baseColor, DecorationType.gray]
+    ],
 ];
 
 //#endregion Constant

--- a/src/test/suite/integration/formatting.test.ts
+++ b/src/test/suite/integration/formatting.test.ts
@@ -81,6 +81,15 @@ suite("Formatting.", () => {
         );
     });
 
+    test("Toggle bold. Use `__`", async () => {
+        await updateConfiguration({ config: [["markdown.extension.bold.indicator", "__"]] });
+        await testCommand('markdown.extension.editing.toggleBold',
+            ['text'], new Selection(0, 0, 0, 4),
+            ['__text__'], new Selection(0, 0, 0, 8)
+        );
+        await resetConfiguration();
+    });
+
     test("Toggle italic. Use `*`", () => {
         return testCommand('markdown.extension.editing.toggleItalic',
             ['text'], new Selection(0, 0, 0, 4),

--- a/src/test/suite/util/configuration.ts
+++ b/src/test/suite/util/configuration.ts
@@ -16,6 +16,7 @@ const Default_Config: readonly IConfigurationRecord[] = [
     ["markdown.extension.preview.autoShowPreviewToSide", false],
     ["markdown.extension.orderedList.marker", "ordered"],
     ["markdown.extension.italic.indicator", "*"],
+    ["markdown.extension.bold.indicator", "**"],
     ["markdown.extension.tableFormatter.normalizeIndentation", false],
     ["editor.insertSpaces", true],
     ["editor.tabSize", 4],


### PR DESCRIPTION
Added configuration option for bold (strong emphasis) indicator. Options are `**` (default) or `__`.