### PR TITLE
Fix decoration for code spans in lists

### DIFF
--- a/src/theming/decorationWorkerRegistry.ts
+++ b/src/theming/decorationWorkerRegistry.ts
@@ -56,7 +56,8 @@ const decorationWorkerRegistry: IWorkerRegistry = {
         const ranges: vscode.Range[] = [];
 
         for (const { content, children, map } of tokens) {
-            const initOffset = text.indexOf(content, document.offsetAt(new vscode.Position(map![0], 0)));
+            let initOffset = document.offsetAt(new vscode.Position(map![0], 0))
+            initOffset = Math.max(text.indexOf(content, initOffset), initOffset);
 
             let beginOffset = initOffset;
             let endOffset = initOffset;


### PR DESCRIPTION
On the master branch, with the following input, [indexOf()](https://github.com/yzhang-gh/vscode-markdown/pull/1134/files#diff-eb3a2c362713d6b38eada70b7b3967bee5c3c45e4f9b7792f1682f12ea6057e4) returns -1 and the outline of the second code span is not displayed. This PR fixes it.

```markdown
**a** `aa`
- a
  `aa`
```

![image](https://user-images.githubusercontent.com/54441600/174522838-2c1242e6-0b5e-4502-a662-536ae7a4a45b.png)
