### PR TITLE
Fix decoration for code spans in task lists

### DIFF
--- a/src/theming/decorationWorkerRegistry.ts
+++ b/src/theming/decorationWorkerRegistry.ts
@@ -61,6 +61,7 @@ const decorationWorkerRegistry: IWorkerRegistry = {
             let beginOffset = initOffset;
             let endOffset = initOffset;
             for (const t of children!) {
+                // see #1135
                 if (t.type === "html_inline") {
                     continue;
                 }

--- a/src/theming/decorationWorkerRegistry.ts
+++ b/src/theming/decorationWorkerRegistry.ts
@@ -61,6 +61,9 @@ const decorationWorkerRegistry: IWorkerRegistry = {
             let beginOffset = initOffset;
             let endOffset = initOffset;
             for (const t of children!) {
+                if (t.type === "html_inline") {
+                    continue;
+                }
                 if (t.type !== "code_inline") {
                     beginOffset += t.content.length; // Not accurate, but enough.
                     continue;


### PR DESCRIPTION
Fixes #1067

When `t.type === "html_inline"`, `t.content` is a HTML tag, but https://github.com/yy0931/vscode-markdown/blob/b7cf0acf56abff059c5c71bc98b9446b62b708d4/src/theming/decorationWorkerRegistry.ts#L68 is assuming that `t.content` is a markdown (e.g. `"- [ ]"`).


![image](https://user-images.githubusercontent.com/54441600/174535885-51d0541a-8d33-4b2c-bb15-51a0592d4bc3.png)
