### PR TITLE
Typo fix '<!-- omit from toc -->'  vs. '<!-- omit in toc -->'.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ See full key binding list in the [keyboard shortcuts](#keyboard-shortcuts-1) sec
   <details>
   <summary>Click to expand</summary>
 
-  1. Add `<!-- omit from toc -->` at the end of a heading to ignore it in TOC\
+  1. Add `<!-- omit in toc -->` at the end of a heading to ignore it in TOC\
     (It can also be placed above a heading)
 
   2. Use `toc.levels` setting.


### PR DESCRIPTION
Hello everyone,
today I think I found an inconsistency. I tried to remove a section's title from the Table Of Contents.
`<!-- omit from toc -->` did not work for me. I guess the ReadMe should state to use `<!-- omit in toc -->` instead.  As `<!-- omit in toc -->` is also shown in the first image of the ReadMe's Table of content section.