### PR TITLE
✨ new config to choose ** or __ to wrap bold text

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ Tip: also support the option `completion.root`
 | `markdown.extension.completion.respectVscodeSearchExclude` | `true`     | Whether to consider `search.exclude` option when providing file path completions                 |
 | `markdown.extension.completion.root`                       |            | Root folder when providing file path completions (It takes effect when the path starts with `/`) |
 | `markdown.extension.italic.indicator`                      | `*`        | Use `*` or `_` to wrap italic text                                                               |
+| `markdown.extension.bold.indicator`                        | `**`       | Use `**` or `__` to wrap bold text                                                               |
 | `markdown.extension.katex.macros`                          | `{}`       | KaTeX macros e.g. `{ "\\name": "expansion", ... }`                                               |
 | `markdown.extension.list.indentationSize`                  | `adaptive` | Use different indentation size for ordered and unordered list                                    |
 | `markdown.extension.list.toggle.candidate-markers`         | `[ "-", "*", "+", "1.", "1)" ]`  | Use a array for toggle ordered list marker e.g. `["*", "1."]`              |

--- a/package.json
+++ b/package.json
@@ -289,6 +289,15 @@
                         "_"
                     ]
                 },
+                "markdown.extension.bold.indicator": {
+                    "type": "string",
+                    "default": "**",
+                    "markdownDescription": "%config.bold.indicator.description%",
+                    "enum": [
+                        "**",
+                        "__"
+                    ]
+                },
                 "markdown.extension.katex.macros": {
                     "type": "object",
                     "default": {},

--- a/package.nls.ja.json
+++ b/package.nls.ja.json
@@ -16,6 +16,7 @@
     "config.completion.respectVscodeSearchExclude": "VS Codeの `#search.exclude#` 設定を使用して、オートコンプリートからファイルを除外する（`node_modules` や、`bower_components` や、`*.code-search` は**常に除外**され、このオプションの影響を受けません）",
     "config.completion.root": "Pathを自動補完する際のルートフォルダ",
     "config.italic.indicator.description": "斜体テキストの囲いに `*` と `_` のどちらを使用するか",
+    "config.bold.indicator.description": "太字の囲み文字に `**` と `__` のどちらを使用するか",
     "config.katex.macros.description": "ユーザ定義のKaTeXマクロ",
     "config.list.indentationSize.description": "リスト構文のインデント形式（TOCの生成にも影響します）\n\nリスト構文のコンテキストによって異なったインデント幅を使用するか、VS Codeにおけるタブのサイズに従うかどうか",
     "config.list.indentationSize.enumDescriptions.adaptive": "コンテキストに応じたインデント幅を使用します。**サブ項目をその親の項目に左揃えで配置**させます。例：\n\n```markdown\n- 親項目\n  - サブ項目\n\n1. 親項目\n   1. サブ項目\n\n10. マーカーが長い親項目\n    1. サブ項目\n```",

--- a/package.nls.json
+++ b/package.nls.json
@@ -16,6 +16,7 @@
     "config.completion.respectVscodeSearchExclude": "Whether to exclude files from auto-completion using VS Code's `#search.exclude#` setting. (`node_modules`, `bower_components` and `*.code-search` are **always excluded**, not affected by this option.)",
     "config.completion.root": "The root folder for path auto-completion.",
     "config.italic.indicator.description": "Use `*` or `_` to wrap italic text.",
+    "config.bold.indicator.description": "Use `**` or `__` to wrap bold text.",
     "config.katex.macros.description": "User-defined KaTeX macros.",
     "config.list.indentationSize.description": "List indentation scheme. (Also affects TOC generation.)\n\nWhether to use different indentation sizes on different list contexts or stick to VS Code's tab size.",
     "config.list.indentationSize.enumDescriptions.adaptive": "Adaptive indentation size according to the context, trying to **left align the sublist with its parent's content**. For example:\n\n```markdown\n- Parent\n  - Sublist\n\n1. Parent\n   1. Sublist\n\n10. Parent with longer marker\n    1. Sublist\n```",

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -12,6 +12,7 @@
     "command.editing.toggleList.title": "触发列表",
     "config.title": "Markdown All in One",
     "config.italic.indicator.description": "使用 `*` 或 `_` 包围斜体文本。",
+    "config.bold.indicator.description": "用 `**` 或 `__` 来括住粗体字。",
     "config.katex.macros.description": "自定义 KaTeX 宏。",
     "config.list.indentationSize.description": "Markdown 列表的缩进方案。（包括目录列表）",
     "config.list.indentationSize.enumDescriptions.adaptive": "参考 **CommonMark Spec**，根据上下文判断缩进大小，并尝试**将子级的左端对齐父级的内容的左端**。比如：\n\n```markdown\n- Parent\n  - Sublist\n\n1. Parent\n   1. Sublist\n\n10. Parent with longer marker\n    1. Sublist\n```",

--- a/src/configuration/model.ts
+++ b/src/configuration/model.ts
@@ -1,4 +1,4 @@
-import type { MarkdownBulletListMarker, MarkdownEmphasisIndicator } from "../contract/MarkdownSpec";
+import type { MarkdownBulletListMarker, MarkdownEmphasisIndicator, MarkdownStrongEmphasisIndicator } from "../contract/MarkdownSpec";
 import type { SlugifyMode } from "../contract/SlugifyMode";
 
 /**
@@ -11,6 +11,7 @@ export interface IConfigurationKeyTypeMap {
     "completion.root": string;
 
     "italic.indicator": MarkdownEmphasisIndicator;
+    "bold.indicator": MarkdownStrongEmphasisIndicator;
 
     /**
      * A collection of custom macros.

--- a/src/contract/MarkdownSpec.ts
+++ b/src/contract/MarkdownSpec.ts
@@ -22,6 +22,15 @@ export const enum MarkdownEmphasisIndicator {
 }
 
 /**
+ * CommonMark strong emphasis indicator.
+ * https://spec.commonmark.org/0.29/#emphasis-and-strong-emphasis
+ */
+ export const enum MarkdownStrongEmphasisIndicator {
+    Asterisk = "**",
+    Underscore = "__",
+}
+
+/**
  * The heading level allowed by the CommonMark Spec.
  * https://spec.commonmark.org/0.29/#atx-headings
  */

--- a/src/formatting.ts
+++ b/src/formatting.ts
@@ -5,8 +5,8 @@ import { fixMarker } from './listEditing';
 
 export function activate(context: ExtensionContext) {
     context.subscriptions.push(
-        commands.registerCommand('markdown.extension.editing.toggleBold', toggleBold),
-        commands.registerCommand('markdown.extension.editing.toggleItalic', toggleItalic),
+        commands.registerCommand('markdown.extension.editing.toggleBold', () => toggleEmphasis(EmphasisType.BOLD)),
+        commands.registerCommand('markdown.extension.editing.toggleItalic', () => toggleEmphasis(EmphasisType.ITALIC)),
         commands.registerCommand('markdown.extension.editing.toggleCodeSpan', toggleCodeSpan),
         commands.registerCommand('markdown.extension.editing.toggleStrikethrough', toggleStrikethrough),
         commands.registerCommand('markdown.extension.editing.toggleMath', () => toggleMath(transTable)),
@@ -27,12 +27,13 @@ const singleLinkRegex: RegExp = createLinkRegex();
 
 // Return Promise because need to chain operations in unit tests
 
-function toggleBold() {
-    return styleByWrapping('**');
+enum EmphasisType {
+    ITALIC,
+    BOLD
 }
 
-function toggleItalic() {
-    let indicator = workspace.getConfiguration('markdown.extension.italic').get<string>('indicator')!;
+function toggleEmphasis(type: EmphasisType) {
+    let indicator = workspace.getConfiguration('markdown.extension.' + EmphasisType[type].toLowerCase()).get<string>('indicator')!;
     return styleByWrapping(indicator);
 }
 

--- a/src/test/suite/integration/formatting.test.ts
+++ b/src/test/suite/integration/formatting.test.ts
@@ -81,6 +81,15 @@ suite("Formatting.", () => {
         );
     });
 
+    test("Toggle bold. Use `__`", async () => {
+        await updateConfiguration({ config: [["markdown.extension.bold.indicator", "__"]] });
+        await testCommand('markdown.extension.editing.toggleBold',
+            ['text'], new Selection(0, 0, 0, 4),
+            ['__text__'], new Selection(0, 0, 0, 8)
+        );
+        await resetConfiguration();
+    });
+
     test("Toggle italic. Use `*`", () => {
         return testCommand('markdown.extension.editing.toggleItalic',
             ['text'], new Selection(0, 0, 0, 4),
@@ -96,7 +105,7 @@ suite("Formatting.", () => {
         );
         await resetConfiguration();
     });
-
+    
     test("Toggle strikethrough. `text|` -> `~~text~~|`", () => {
         return testCommand('markdown.extension.editing.toggleStrikethrough',
             ['text'], new Selection(0, 4, 0, 4),

--- a/src/test/suite/util/configuration.ts
+++ b/src/test/suite/util/configuration.ts
@@ -16,6 +16,7 @@ const Default_Config: readonly IConfigurationRecord[] = [
     ["markdown.extension.preview.autoShowPreviewToSide", false],
     ["markdown.extension.orderedList.marker", "ordered"],
     ["markdown.extension.italic.indicator", "*"],
+    ["markdown.extension.bold.indicator", "**"],
     ["markdown.extension.tableFormatter.normalizeIndentation", false],
     ["markdown.extension.tableFormatter.delimiterRowNoPadding", false],
     ["editor.insertSpaces", true],


### PR DESCRIPTION
Inspired by the existing setting `markdown.extension.italic.indicator` I wanted the same setting for bold text (I think it's just way easier to read with underscores).

So I implemented it. This is my first contribution here, but I tried my best to not miss anything - descriptions, tests, the MarkdownSpec, and your commit msg style :)

Please let me know if something needs rework, then I'll update it. I haven't tested the change locally, but I expect the unit test to run in your CI pipeline which should fail if it doesn't work. 

I'd be really happy if this change makes it into the extension :)