### PR TITLE
Add keyboard shortcuts to toggle between list and task list formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ Tip: also support the option `completion.root`
 | <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>]</kbd>                | Toggle heading (uplevel)         |
 | <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>[</kbd>                | Toggle heading (downlevel)       |
 | <kbd>Ctrl</kbd>/<kbd>Cmd</kbd> + <kbd>M</kbd>                    | Toggle math environment          |
+| <kbd>Shift</kbd> + <kbd>Alt</kbd> + <kbd>C</kbd>                 | Toggle list <--> task list       |
 | <kbd>Alt</kbd> + <kbd>C</kbd>                                    | Check/Uncheck task list item     |
 | <kbd>Ctrl</kbd>/<kbd>Cmd</kbd> + <kbd>Shift</kbd> + <kbd>V</kbd> | Toggle preview                   |
 | <kbd>Ctrl</kbd>/<kbd>Cmd</kbd> + <kbd>K</kbd> <kbd>V</kbd>       | Toggle preview to side           |

--- a/package.json
+++ b/package.json
@@ -243,6 +243,11 @@
                 "when": "editorTextFocus && editorLangId =~ /^markdown$|^rmd$|^quarto$/ && !suggestWidgetVisible"
             },
             {
+                "command": "markdown.extension.toggleTaskList",
+                "key": "shift+alt+c",
+                "when": "editorTextFocus && editorLangId =~ /^markdown$|^rmd$|^quarto$/"
+            },
+            {
                 "command": "markdown.extension.checkTaskList",
                 "key": "alt+c",
                 "when": "editorTextFocus && editorLangId =~ /^markdown$|^rmd$|^quarto$/"

--- a/src/test/suite/integration/listEditing.test.ts
+++ b/src/test/suite/integration/listEditing.test.ts
@@ -227,6 +227,66 @@ suite("List editing.", () => {
             new Selection(0, 10, 0, 10));
     });
 
+    test("List/TaskList toggle. 1: Check single line,list to task list", () => {
+        return testCommand('markdown.extension.toggleTaskList',
+            [
+                '- test'
+            ],
+            new Selection(0, 0, 0, 0),
+            [
+                '- [ ] test'
+            ],
+            new Selection(0, 0, 0, 0),
+        );
+    });
+
+    test("List/TaskList toggle. 2: Check single line,task list to list", () => {
+        return testCommand('markdown.extension.toggleTaskList',
+            [
+                '-   [ ]   test'
+            ],
+            new Selection(0, 0, 0, 0),
+            [
+                '- test'
+            ],
+            new Selection(0, 0, 0, 0),
+        );
+    });
+
+    test("List/TaskList toggle. 3: Check multiple lines,list to task list", () => {
+        return testCommand('markdown.extension.toggleTaskList',
+            [
+                '- test',
+                '  -   test',
+                '- test',
+            ],
+            new Selection(1, 0, 2, 1),
+            [
+                '- test',
+                '  - [ ] test',
+                '- [ ] test',
+            ],
+            new Selection(1, 0, 2, 1),
+        );
+    });
+
+    test("List/TaskList toggle. 4: Check multiple lines,task list to list", () => {
+        return testCommand('markdown.extension.toggleTaskList',
+            [
+                '    -   [x] test',
+                '  - test',
+                '- [ ]  test',
+            ],
+            new Selection(0, 0, 2, 1),
+            [
+                '    - test',
+                '  - test',
+                '- test',
+            ],
+            new Selection(0, 0, 2, 1),
+        );
+    });
+
     test("List toggle. 1: Check single line", () => {
         return testCommand('markdown.extension.checkTaskList',
             [


### PR DESCRIPTION
I've added a shortcut key that allows you to toggle multiple lines between List and Task List formats, just like the Check/Uncheck function.