### PR TITLE
toggleBold when editorHasSelection

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
                 "command": "markdown.extension.editing.toggleBold",
                 "key": "ctrl+b",
                 "mac": "cmd+b",
-                "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^markdown$|^rmd$|^quarto$/"
+                "when": "editorHasSelection && editorTextFocus && !editorReadonly && editorLangId =~ /^markdown$|^rmd$|^quarto$/"
             },
             {
                 "command": "markdown.extension.editing.toggleItalic",


### PR DESCRIPTION
There's a conflict between the shortcut key <kbd>cmd+b</kbd> for `toggleBold` and `View: Toggle Primary Side Bar Visibility`, I found that adding another condition editorHasSelection can bypass this issue and improve the UX.