### PR TITLE
Add export HTML to right click menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
             "editor/context": [
                 {
                   "command": "markdown.extension.printToHtml",
-                  "when": "editorLangId =~ /^markdown$|^rmd$|^quarto$/",
+                  "when": "editorLangId =~ /^markdown$|^rmd$|^quarto$/"
                 }
             ]
         },

--- a/package.json
+++ b/package.json
@@ -140,18 +140,18 @@
             }
         ],
         "menus": {
-          "editor/context": [
-            {
-              "command": "markdown.extension.printToHtml",
-              "when": "editorLangId =~ /^markdown$|^rmd$|^quarto$/",
-              "group": "markdown.print@1"
-            },
-            {
-              "command": "markdown.extension.printToHtmlBatch",
-              "when": "editorLangId =~ /^markdown$|^rmd$|^quarto$/ && workspaceFolderCount >= 1",
-              "group": "markdown.print@2"
-            }
-          ]
+            "editor/context": [
+                {
+                    "command": "markdown.extension.printToHtml",
+                    "when": "editorLangId =~ /^markdown$|^rmd$|^quarto$/",
+                    "group": "markdown.print@1"
+                },
+                {
+                    "command": "markdown.extension.printToHtmlBatch",
+                    "when": "editorLangId =~ /^markdown$|^rmd$|^quarto$/ && workspaceFolderCount >= 1",
+                    "group": "markdown.print@2"
+                }
+            ]
         },
         "keybindings": [
             {

--- a/package.json
+++ b/package.json
@@ -139,6 +139,14 @@
                 "category": "Markdown All in One"
             }
         ],
+        "menus": {
+            "editor/context": [
+                {
+                  "command": "markdown.extension.printToHtml",
+                  "when": "editorLangId =~ /^markdown$|^rmd$|^quarto$/",
+                }
+            ]
+        },
         "keybindings": [
             {
                 "command": "markdown.extension.editing.toggleBold",

--- a/package.json
+++ b/package.json
@@ -140,12 +140,18 @@
             }
         ],
         "menus": {
-            "editor/context": [
-                {
-                  "command": "markdown.extension.printToHtml",
-                  "when": "editorLangId =~ /^markdown$|^rmd$|^quarto$/"
-                }
-            ]
+          "editor/context": [
+            {
+              "command": "markdown.extension.printToHtml",
+              "when": "editorLangId =~ /^markdown$|^rmd$|^quarto$/",
+              "group": "markdown.print@1"
+            },
+            {
+              "command": "markdown.extension.printToHtmlBatch",
+              "when": "editorLangId =~ /^markdown$|^rmd$|^quarto$/ && workspaceFolderCount >= 1",
+              "group": "markdown.print@2"
+            }
+          ]
         },
         "keybindings": [
             {


### PR DESCRIPTION
Add `markdown.extension.printToHtml` and `markdown.extension.printToHtmlBatch` command to right click menu (#1275). 
Tested on my VSCode and worked well. Since this is my first time making pull requests, please tell me if I made something wrong. 