### PR TITLE
Optimize the indentation behavior of list items when pressing enter

### DIFF
--- a/src/test/suite/integration/listEditing.test.ts
+++ b/src/test/suite/integration/listEditing.test.ts
@@ -47,9 +47,22 @@ suite("List editing.", () => {
             [
                 '- item1',
                 '',
-                ''
             ],
-            new Selection(2, 0, 2, 0));
+            new Selection(1, 0, 1, 0));
+    });
+    
+    test("Enter key. Outdent list item when there is a space before it, until the front is empty", () => {
+        return testCommand('markdown.extension.onEnterKey',
+            [
+                '- item1',
+                '    - '
+            ],
+            new Selection(1, 6, 1, 6),
+            [
+                '- item1',
+                '- '
+            ],
+            new Selection(1, 2, 1, 2));
     });
 
     test("Enter key. List marker `*`", () => {


### PR DESCRIPTION
When cursor in non-root list items, press `enter` to perform outdent, which is more in line with the list behavior  of general platforms.