### PR TITLE
feat: add github-alerts support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,14 +15,15 @@
                 "highlight.js": "^11.5.1",
                 "image-size": "^0.9.3",
                 "katex": "^0.16.4",
-                "markdown-it": "^12.3.2",
+                "markdown-it": "^13.0.2",
+                "markdown-it-github-alerts": "^0.1.2",
                 "markdown-it-task-lists": "^2.1.1",
                 "string-similarity": "^4.0.4"
             },
             "devDependencies": {
                 "@types/glob": "^7.2.0",
                 "@types/katex": "^0.14.0",
-                "@types/markdown-it": "^12.2.3",
+                "@types/markdown-it": "^13.0.7",
                 "@types/mocha": "^9.1.0",
                 "@types/node": "~14.18.13",
                 "@types/string-similarity": "^4.0.0",
@@ -36,7 +37,7 @@
                 "webpack-cli": "^4.9.2"
             },
             "engines": {
-                "vscode": "^1.63.0"
+                "vscode": "^1.72.0"
             }
         },
         "node_modules/@discoveryjs/json-ext": {
@@ -124,9 +125,9 @@
             "dev": true
         },
         "node_modules/@types/markdown-it": {
-            "version": "12.2.3",
-            "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-12.2.3.tgz",
-            "integrity": "sha512-GKMHFfv3458yYy+v/N8gjufHO6MSZKCOXpZc5GXIWWy8uldwfmPn98vp81gZ5f9SVw8YYBctgfJ22a2d7AOMeQ==",
+            "version": "13.0.7",
+            "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-13.0.7.tgz",
+            "integrity": "sha512-U/CBi2YUUcTHBt5tjO2r5QV/x0Po6nsYwQU4Y04fBS6vfoImaiZ6f8bi3CjTCxBPQSO1LMyUqkByzi8AidyxfA==",
             "dev": true,
             "dependencies": {
                 "@types/linkify-it": "*",
@@ -1511,9 +1512,9 @@
             }
         },
         "node_modules/linkify-it": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
-            "integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-4.0.1.tgz",
+            "integrity": "sha512-C7bfi1UZmoj8+PQx22XyeXCuBlokoyWQL5pWSP+EI6nzRylyThouddufc2c1NDIcP9k5agmN9fLpA7VNJfIiqw==",
             "dependencies": {
                 "uc.micro": "^1.0.1"
             }
@@ -1577,13 +1578,13 @@
             }
         },
         "node_modules/markdown-it": {
-            "version": "12.3.2",
-            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
-            "integrity": "sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==",
+            "version": "13.0.2",
+            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-13.0.2.tgz",
+            "integrity": "sha512-FtwnEuuK+2yVU7goGn/MJ0WBZMM9ZPgU9spqlFs7/A/pDIUNSOQZhUgOqYCficIuR2QaFnrt8LHqBWsbTAoI5w==",
             "dependencies": {
                 "argparse": "^2.0.1",
-                "entities": "~2.1.0",
-                "linkify-it": "^3.0.1",
+                "entities": "~3.0.1",
+                "linkify-it": "^4.0.1",
                 "mdurl": "^1.0.1",
                 "uc.micro": "^1.0.5"
             },
@@ -1591,18 +1592,21 @@
                 "markdown-it": "bin/markdown-it.js"
             }
         },
+        "node_modules/markdown-it-github-alerts": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/markdown-it-github-alerts/-/markdown-it-github-alerts-0.1.2.tgz",
+            "integrity": "sha512-jtCrfFxXR6c/bNRBvWkoqUquEDdIF9q7/gNZjP47W96kaIiBMiYHbpf468IPeZJB5BVRls6+IXGchhQSTxy0DQ==",
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            },
+            "peerDependencies": {
+                "markdown-it": "^13.0.0"
+            }
+        },
         "node_modules/markdown-it-task-lists": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/markdown-it-task-lists/-/markdown-it-task-lists-2.1.1.tgz",
             "integrity": "sha512-TxFAc76Jnhb2OUu+n3yz9RMu4CwGfaT788br6HhEDlvWfdeJcLUsxk1Hgw2yJio0OXsxv7pyIPmvECY7bMbluA=="
-        },
-        "node_modules/markdown-it/node_modules/entities": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
-            "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
-            "funding": {
-                "url": "https://github.com/fb55/entities?sponsor=1"
-            }
         },
         "node_modules/mdurl": {
             "version": "1.0.1",
@@ -2831,9 +2835,9 @@
             "dev": true
         },
         "@types/markdown-it": {
-            "version": "12.2.3",
-            "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-12.2.3.tgz",
-            "integrity": "sha512-GKMHFfv3458yYy+v/N8gjufHO6MSZKCOXpZc5GXIWWy8uldwfmPn98vp81gZ5f9SVw8YYBctgfJ22a2d7AOMeQ==",
+            "version": "13.0.7",
+            "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-13.0.7.tgz",
+            "integrity": "sha512-U/CBi2YUUcTHBt5tjO2r5QV/x0Po6nsYwQU4Y04fBS6vfoImaiZ6f8bi3CjTCxBPQSO1LMyUqkByzi8AidyxfA==",
             "dev": true,
             "requires": {
                 "@types/linkify-it": "*",
@@ -3886,9 +3890,9 @@
             "dev": true
         },
         "linkify-it": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
-            "integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-4.0.1.tgz",
+            "integrity": "sha512-C7bfi1UZmoj8+PQx22XyeXCuBlokoyWQL5pWSP+EI6nzRylyThouddufc2c1NDIcP9k5agmN9fLpA7VNJfIiqw==",
             "requires": {
                 "uc.micro": "^1.0.1"
             }
@@ -3934,23 +3938,22 @@
             }
         },
         "markdown-it": {
-            "version": "12.3.2",
-            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
-            "integrity": "sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==",
+            "version": "13.0.2",
+            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-13.0.2.tgz",
+            "integrity": "sha512-FtwnEuuK+2yVU7goGn/MJ0WBZMM9ZPgU9spqlFs7/A/pDIUNSOQZhUgOqYCficIuR2QaFnrt8LHqBWsbTAoI5w==",
             "requires": {
                 "argparse": "^2.0.1",
-                "entities": "~2.1.0",
-                "linkify-it": "^3.0.1",
+                "entities": "~3.0.1",
+                "linkify-it": "^4.0.1",
                 "mdurl": "^1.0.1",
                 "uc.micro": "^1.0.5"
-            },
-            "dependencies": {
-                "entities": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
-                    "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w=="
-                }
             }
+        },
+        "markdown-it-github-alerts": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/markdown-it-github-alerts/-/markdown-it-github-alerts-0.1.2.tgz",
+            "integrity": "sha512-jtCrfFxXR6c/bNRBvWkoqUquEDdIF9q7/gNZjP47W96kaIiBMiYHbpf468IPeZJB5BVRls6+IXGchhQSTxy0DQ==",
+            "requires": {}
         },
         "markdown-it-task-lists": {
             "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -629,7 +629,10 @@
         "markdown.markdownItPlugins": true,
         "markdown.previewStyles": [
             "./media/checkbox.css",
-            "./node_modules/katex/dist/katex.min.css"
+            "./node_modules/katex/dist/katex.min.css",
+            "./node_modules/markdown-it-github-alerts/styles/github-colors-light.css",
+            "./node_modules/markdown-it-github-alerts/styles/github-colors-dark-media.css",
+            "./node_modules/markdown-it-github-alerts/styles/github-base.css"
         ],
         "grammars": [
             {
@@ -673,14 +676,15 @@
         "highlight.js": "^11.5.1",
         "image-size": "^0.9.3",
         "katex": "^0.16.4",
-        "markdown-it": "^12.3.2",
+        "markdown-it": "^13.0.2",
+        "markdown-it-github-alerts": "^0.1.2",
         "markdown-it-task-lists": "^2.1.1",
         "string-similarity": "^4.0.4"
     },
     "devDependencies": {
         "@types/glob": "^7.2.0",
         "@types/katex": "^0.14.0",
-        "@types/markdown-it": "^12.2.3",
+        "@types/markdown-it": "^13.0.7",
         "@types/mocha": "^9.1.0",
         "@types/node": "~14.18.13",
         "@types/string-similarity": "^4.0.0",

--- a/src/markdown-it-plugin-provider.ts
+++ b/src/markdown-it-plugin-provider.ts
@@ -9,6 +9,7 @@ const katexOptions: KatexOptions = { throwOnError: false };
  */
 export function extendMarkdownIt(md: MarkdownIt): MarkdownIt {
     md.use(require("markdown-it-task-lists"), {enabled: true});
+    md.use(require("markdown-it-github-alerts"))
 
     if (configManager.get("math.enabled")) {
         // We need side effects. (#521)


### PR DESCRIPTION
should close #1350 

`markdown-it-github-alerts` required `markdown-it@13` so I bumped it without issue. 

It still seems to work with `markdown-it@12` but rather bump it anyways.

previews:
![image](https://github.com/yzhang-gh/vscode-markdown/assets/1631886/6150b1f1-a936-4697-83dc-88dca5665d31)

![image](https://github.com/yzhang-gh/vscode-markdown/assets/1631886/00b2f958-e26c-4958-a485-a9a0de21e750)
