### PR TITLE
Update slugify method for Azure DevOps TOC generation

### DIFF
--- a/src/util/slugify.ts
+++ b/src/util/slugify.ts
@@ -55,17 +55,24 @@ const Slugify_Methods: { readonly [mode in SlugifyMode]: (rawContent: string, en
     [SlugifyMode.AzureDevOps]: (slug: string): string => {
         // https://markdown-all-in-one.github.io/docs/specs/slugify/azure-devops.html
         // Encode every character. Although opposed by RFC 3986, it's the only way to solve #802.
-        return Array.from(
-            utf8Encoder.encode(
-                slug
-                    .trim()
+
+        slug =  slug.trim()
                     .toLowerCase()
                     .replace(/\p{Zs}/gu, "-")
-            ),
-            (b) => "%" + b.toString(16)
-        )
-            .join("")
-            .toUpperCase();
+
+        if(/^\d/.test(slug)) {
+            slug = Array.from(
+                utf8Encoder.encode(slug),
+                (b) => "%" + b.toString(16)
+            )
+                .join("")
+                .toUpperCase();
+        }
+        else {
+            slug =  encodeURIComponent(slug)
+        }
+        
+        return slug
     },
 
     [SlugifyMode.BitbucketCloud]: (slug: string, env: object): string => {


### PR DESCRIPTION
Hi yzhang,

I have updated the slugify method for Azure DevOps used when generating/updating a TOC in a markdown file. For most headers, it will keep working, but simultaneously non-UTF8-encoded readable slugs. I have read #802, and unfortunately, TOC entries starting with numbers remain problematic and are generally rendered as references to work items in Azure DevOps markdown render. Therefore, the original slugify method is only used to fully encode these using the original slugify method, which produces working references, albeit far-less readable for us humans.

* Perform partial URI encoding for non-number indexed TOC items.
* Perform original method if TOC entry starts with number.