### PR TITLE
Update slugify method for Azure DevOps TOC generation to be more readable

### DIFF
--- a/src/test/suite/unit/slugify.test.ts
+++ b/src/test/suite/unit/slugify.test.ts
@@ -9,9 +9,14 @@ type ICase = readonly [string, string];
  */
 const cases: Readonly<Record<SlugifyMode, readonly ICase[]>> = {
     [SlugifyMode.AzureDevOps]: [
-        ["A !\"#$%&'()*+,-./:;<=>?@[\\\\]^_`{|}~", "%61%2D%21%22%23%24%25%26%27%28%29%2A%2B%2C%2D%2E%2F%3A%3B%3C%3D%3E%3F%40%5B%5C%5C%5D%5E%5F%60%7B%7C%7D%7E"],
-        ["W\u{0020}\u{00A0}\u{2003}\u{202F}\u{205F}\u{3000}\u{1680}S", "%77%2D%2D%2D%2D%2D%2D%2D%73"],
+        ["A !\"#$%&'()*+,-./:;<=>?@[\\\\]^_`{|}~", "a-!%22%23%24%25%26'()*%2B%2C-.%2F%3A%3B%3C%3D%3E%3F%40%5B%5C%5C%5D%5E_%60%7B%7C%7D~"],
+        ["W\u{0020}\u{00A0}\u{2003}\u{202F}\u{205F}\u{3000}\u{1680}S", "w-------s"],
         ["1\u{0020}\u{007F}\u{0080}\u{07FF}\u{0800}\u{FFFF}\u{10000}\u{10FFFF}2", "%31%2D%7F%C2%80%DF%BF%E0%A0%80%EF%BF%BF%F0%90%80%80%F4%8F%BF%BF%32"], // Test UTF-8 encoding.
+        ["1. Hi, there!!!", "%31%2E%2D%68%69%2C%2D%74%68%65%72%65%21%21%21"],
+        ["Hi, there!!! without and index number", "hi%2C-there!!!-without-and-index-number"],
+        ["Design & Process", "design-%26-process"],
+        ["These symbols -\_.!~\*'(), should remain", "these-symbols--_.!~*'()%2C-should-remain"],
+        ["1. These symbols -\_.!~\*'(), should be fully encoded because of the number in front", "%31%2E%2D%74%68%65%73%65%2D%73%79%6D%62%6F%6C%73%2D%2D%5F%2E%21%7E%2A%27%28%29%2C%2D%73%68%6F%75%6C%64%2D%62%65%2D%66%75%6C%6C%79%2D%65%6E%63%6F%64%65%64%2D%62%65%63%61%75%73%65%2D%6F%66%2D%74%68%65%2D%6E%75%6D%62%65%72%2D%69%6E%2D%66%72%6F%6E%74"],
     ],
 
     [SlugifyMode.BitbucketCloud]: [],

--- a/src/util/slugify.ts
+++ b/src/util/slugify.ts
@@ -55,17 +55,24 @@ const Slugify_Methods: { readonly [mode in SlugifyMode]: (rawContent: string, en
     [SlugifyMode.AzureDevOps]: (slug: string): string => {
         // https://markdown-all-in-one.github.io/docs/specs/slugify/azure-devops.html
         // Encode every character. Although opposed by RFC 3986, it's the only way to solve #802.
-        return Array.from(
-            utf8Encoder.encode(
-                slug
-                    .trim()
+
+        slug =  slug.trim()
                     .toLowerCase()
                     .replace(/\p{Zs}/gu, "-")
-            ),
-            (b) => "%" + b.toString(16)
-        )
-            .join("")
-            .toUpperCase();
+
+        if(/^\d/.test(slug)) {
+            slug = Array.from(
+                utf8Encoder.encode(slug),
+                (b) => "%" + b.toString(16)
+            )
+                .join("")
+                .toUpperCase();
+        }
+        else {
+            slug =  encodeURIComponent(slug)
+        }
+        
+        return slug
     },
 
     [SlugifyMode.BitbucketCloud]: (slug: string, env: object): string => {


### PR DESCRIPTION
Hi yzhang,

I have updated the slugify method for Azure DevOps used when generating/updating a TOC in a markdown file. For most headers, it will keep working, but simultaneously non-UTF8-encoded readable slugs. I have read https://github.com/yzhang-gh/vscode-markdown/issues/802, and unfortunately, TOC entries starting with numbers remain problematic and are generally rendered as references to work items in Azure DevOps markdown render. Therefore, the original slugify method is only used to fully encode these using the original slugify method, which produces working references, albeit far-less readable for us humans.

* Perform partial URI encoding for non-number indexed TOC items.
* Perform original method if TOC entry starts with number.