### PR TITLE
Add automatic list renumbering when deleting lines

### DIFF
--- a/package.json
+++ b/package.json
@@ -300,6 +300,12 @@
                 "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^markdown$|^rmd$|^quarto$/ && !suggestWidgetVisible"
             },
             {
+                "command": "markdown.extension.onDeleteLines",
+                "key": "ctrl+shift+k",
+                "mac": "cmd+shift+k",
+                "when": "editorTextFocus && !editorReadonly && editorLangId =~ /^markdown$|^rmd$|^quarto$/ && !suggestWidgetVisible"
+            },
+            {
                 "command": "markdown.extension.onIndentLines",
                 "key": "ctrl+]",
                 "mac": "cmd+]",

--- a/src/listEditing.ts
+++ b/src/listEditing.ts
@@ -17,7 +17,8 @@ export function activate(context: ExtensionContext) {
         commands.registerCommand('markdown.extension.onCopyLineDown', onCopyLineDown),
         commands.registerCommand('markdown.extension.onCopyLineUp', onCopyLineUp),
         commands.registerCommand('markdown.extension.onIndentLines', onIndentLines),
-        commands.registerCommand('markdown.extension.onOutdentLines', onOutdentLines)
+        commands.registerCommand('markdown.extension.onOutdentLines', onOutdentLines),
+        commands.registerCommand('markdown.extension.onDeleteLines', onDeleteLines)
     );
 }
 
@@ -545,6 +546,12 @@ function onIndentLines() {
 function onOutdentLines() {
     const editor = window.activeTextEditor!;
     return outdent(editor).then(() => fixMarker(editor));
+}
+
+function onDeleteLines() {
+    const editor = window.activeTextEditor!;
+    return commands.executeCommand('editor.action.deleteLines')
+        .then(() => fixMarker(editor));
 }
 
 export function deactivate() { }

--- a/src/test/suite/integration/listRenumbering.test.ts
+++ b/src/test/suite/integration/listRenumbering.test.ts
@@ -492,4 +492,53 @@ suite("Ordered list renumbering.", () => {
             ],
             new Selection(1, 0, 3, 0));
     });
+
+    test("Delete Line. Fix ordered marker. Delete middle item", () => {
+        return testCommand('markdown.extension.onDeleteLines',
+            [
+                '1. one',
+                '2. two',
+                '3. three'
+            ],
+            new Selection(1, 0, 1, 0),
+            [
+                '1. one',
+                '2. three'
+            ],
+            new Selection(1, 0, 1, 0));
+    });
+
+    test("Delete Line. Fix ordered marker. Delete first item", () => {
+        return testCommand('markdown.extension.onDeleteLines',
+            [
+                '1. one',
+                '2. two',
+                '3. three'
+            ],
+            new Selection(0, 0, 0, 0),
+            [
+                '1. two',
+                '2. three'
+            ],
+            new Selection(0, 0, 0, 0));
+    });
+
+    test("Delete Line. Fix ordered marker. Delete in nested list", () => {
+        return testCommand('markdown.extension.onDeleteLines',
+            [
+                '1. one',
+                '   1. nested1',
+                '   2. nested2',
+                '   3. nested3',
+                '2. two'
+            ],
+            new Selection(2, 0, 2, 0),
+            [
+                '1. one',
+                '   1. nested1',
+                '   2. nested3',
+                '2. two'
+            ],
+            new Selection(2, 0, 2, 0));
+    });
 });


### PR DESCRIPTION
## Summary
This PR adds automatic ordered list renumbering when using the delete lines command (Ctrl+Shift+K), consistent with existing behavior for move/copy line operations.

Fixes #668

## Changes
- Add `markdown.extension.onDeleteLines` command with keybinding (Ctrl+Shift+K / Cmd+Shift+K)
- Implement list marker fixing after line deletion
- Add comprehensive test coverage for various deletion scenarios (middle item, first item, nested lists)

## Testing
- All existing tests pass
- Added 3 new test cases covering different deletion scenarios

## Motivation
Currently, when deleting lines in an ordered list using Ctrl+Shift+K, the list markers don't get renumbered. This is inconsistent with the behavior of moving/copying lines, which do trigger renumbering. This PR brings consistency to list editing operations.

## Example
**Before**: Deleting line 2 in an ordered list leaves incorrect numbering
```markdown
1. one
2. two   <- delete this
3. three

Result:
1. one
3. three  <- Wrong number!
```

**After**: Automatic renumbering
```markdown
1. one
2. two   <- delete this
3. three

Result:
1. one
2. three  <- Correctly renumbered!
```
