### PR TITLE
 Add emoji support to table formatter using Extended_Pictographic

### DIFF
--- a/src/tableFormatter.ts
+++ b/src/tableFormatter.ts
@@ -136,8 +136,11 @@ class MarkdownDocumentFormatter implements vscode.DocumentFormattingEditProvider
         // Regex to extract cell content.
         // GitHub #24
         const fieldRegExp = new RegExp(/((\\\||[^\|])*)\|/gu);
+        // Emoji and CJK characters with double visual width (width 2)
         // https://www.ling.upenn.edu/courses/Spring_2003/ling538/UnicodeRanges.html
-        const cjkRegex = /[\u3000-\u9fff\uac00-\ud7af\uff01-\uff60]/g;
+        // Extended_Pictographic includes all graphical emoji chars
+        // CJK ranges: U+3000-U+9FFF, U+AC00-U+D7AF, U+FF01-U+FF60
+        const doubleWidthRegex = /\p{Extended_Pictographic}|[\u3000-\u9fff\uac00-\ud7af\uff01-\uff60]/gu;
 
         const lines = rows.map((row, iRow) => {
             // Normalize
@@ -165,13 +168,14 @@ class MarkdownDocumentFormatter implements vscode.DocumentFormattingEditProvider
                 // They don't reflect how text layout engines really work.
                 // For more information, please consult UAX #11.
                 // A grapheme cluster may comprise multiple Unicode code points.
-                // One CJK grapheme consists of one CJK code point, in NFC.
                 // In typical fixed-width typesetting without ligature, one grapheme is finally mapped to one glyph.
-                // Such a glyph is usually the same width as an ASCII letter, but a CJK glyph is twice.
+                // Such a glyph is usually the same width as an ASCII letter.
+                // However, emoji symbols and CJK characters have double width in most fonts.
+                // We add the count of double-width characters to the grapheme count to get visual width.
 
                 const graphemeCount = splitter.countGraphemes(cell);
-                const cjkPoints = cell.match(cjkRegex);
-                const width = graphemeCount + (cjkPoints?.length ?? 0);
+                const doubleWidthChars = cell.match(doubleWidthRegex);
+                const width = graphemeCount + (doubleWidthChars?.length ?? 0);
                 colWidth[iCol] = Math.max(colWidth[iCol] || 0, width);
 
                 iCol++;
@@ -219,10 +223,8 @@ class MarkdownDocumentFormatter implements vscode.DocumentFormattingEditProvider
                 const visualWidth = colWidth[iCol];
                 let jsLength = splitter.splitGraphemes(cell + ' '.repeat(visualWidth)).slice(0, visualWidth).join('').length;
 
-                const cjkPoints = cell.match(cjkRegex);
-                if (cjkPoints) {
-                    jsLength -= cjkPoints.length;
-                }
+                // Subtract double-width characters (emoji and CJK)
+                jsLength -= cell.match(doubleWidthRegex)?.length ?? 0;
 
                 return this.alignText(cell, colAlign[iCol], jsLength);
             });

--- a/src/test/suite/integration/tableFormatter.test.ts
+++ b/src/test/suite/integration/tableFormatter.test.ts
@@ -326,7 +326,7 @@ suite("Table formatter.", () => {
                 '|---|:---|---:|:---:|',
                 '| w | x  |  y |  z  |'
             ],
-            new Selection(0,0,0,0));
+            new Selection(0, 0, 0, 0));
         await resetConfiguration();
     });
 
@@ -344,7 +344,131 @@ suite("Table formatter.", () => {
                 '|---|:-------|---------:|:---------:|',
                 '| w | x      | y-longer |     z     |'
             ],
-            new Selection(0,0,0,0));
+            new Selection(0, 0, 0, 0));
         await resetConfiguration();
+    });
+
+    test("Emoji in table cells", () => {
+        return testCommand('editor.action.formatDocument',
+            [
+                '| Value |',
+                '| ----- |',
+                '| ✅✅✅ |',
+                '| ⚠️⚠️ |',
+                '| ❌ |'
+            ],
+            new Selection(0, 0, 0, 0),
+            [
+                '| Value  |',
+                '| ------ |',
+                '| ✅✅✅ |',
+                '| ⚠️⚠️   |',
+                '| ❌     |'
+            ],
+            new Selection(0, 0, 0, 0));
+    });
+
+    test("Emoji with text in table cells", () => {
+        return testCommand('editor.action.formatDocument',
+            [
+                '| Status | Description |',
+                '| ------ | ----------- |',
+                '| ✅ OK | Everything is fine |',
+                '| ⚠️ Warn | Be careful |',
+                '| ❌ Error | Something went wrong |'
+            ],
+            new Selection(0, 0, 0, 0),
+            [
+                '| Status   | Description          |',
+                '| -------- | -------------------- |',
+                '| ✅ OK    | Everything is fine   |',
+                '| ⚠️ Warn  | Be careful           |',
+                '| ❌ Error | Something went wrong |',
+            ],
+            new Selection(0, 0, 0, 0));
+    });
+
+    test("Mixed emoji and other symbols", () => {
+        return testCommand('editor.action.formatDocument',
+            [
+                '| Value |',
+                '| ----- |',
+                '| + |',
+                '| ✅ |',
+                '| ! |',
+                '| ⚠️ |',
+                '| x |',
+                '| ❌ |'
+            ],
+            new Selection(0, 0, 0, 0),
+            [
+                '| Value |',
+                '| ----- |',
+                '| +     |',
+                '| ✅    |',
+                '| !     |',
+                '| ⚠️    |',
+                '| x     |',
+                '| ❌    |'
+            ],
+            new Selection(0, 0, 0, 0));
+    });
+
+    test("Extended_Pictographic emoji", () => {
+        return testCommand('editor.action.formatDocument',
+            [
+                '| Status | Icon',
+                '| ------ | ----',
+                '| Done   | ✨   ',
+                '| Fire   | 🔥   ',
+                '| Target | 🎯   ',
+                '| Spark  | 🌟   '
+            ],
+            new Selection(0, 0, 0, 0),
+            [
+                '| Status | Icon |',
+                '| ------ | ---- |',
+                '| Done   | ✨   |',
+                '| Fire   | 🔥   |',
+                '| Target | 🎯   |',
+                '| Spark  | 🌟   |'
+            ],
+            new Selection(0, 0, 0, 0));
+    });
+
+    test("Mixed CJK and emoji", () => {
+        return testCommand('editor.action.formatDocument',
+            [
+                '| 中文 | 日本語 | 状态',
+                '| ---- | ------ | ----',
+                '| 测试 | テスト | ⏳   ',
+                '| 完成 | 完了   | ✅   '
+            ],
+            new Selection(0, 0, 0, 0),
+            [
+                '| 中文 | 日本語 | 状态 |',
+                '| ---- | ------ | ---- |',
+                '| 测试 | テスト | ⏳   |',
+                '| 完成 | 完了   | ✅   |'
+            ],
+            new Selection(0, 0, 0, 0));
+    });
+
+    test("CheckMarks: normal text vs emoji", () => {
+        return testCommand('editor.action.formatDocument',
+            [
+                '| Normal | Emoji | Mixed',
+                '| ------ | ----- | -----',
+                '| ✓      | ✅    | ✅✓   ',
+                '| ✗      | ❌    | ❌✗   '
+            ],
+            new Selection(0, 0, 0, 0),
+            [
+                '| Normal | Emoji | Mixed |',
+                '| ------ | ----- | ----- |',
+                '| ✓      | ✅    | ✅✓   |',
+                '| ✗      | ❌    | ❌✗   |'
+            ],
+            new Selection(0, 0, 0, 0));
     });
 });


### PR DESCRIPTION
Add emoji support to table formatter. Emoji symbols are now detected as double-width characters (2 columns), while text symbols like ✓✗ remain single-width (1 column).

Implemented using Unicode Extended_Pictographic (`\p{Extended_Pictographic}`) for automatic emoji detection.

```typescript
const doubleWidthRegex = /\p{Extended_Pictographic}|[\u3000-\u9fff\uac00-\ud7af\uff01-\uff60]/gu;
```

Extended_Pictographic automatically:
- Includes all modern emoji (including those from Supplementary Planes U+1F000+)
- Excludes text symbols ✓(U+2713) and ✗(U+2717) from Dingbats

### Examples

✅❌⚠️🔄⏱️ etc. will have double-width
✓✗ will stay single-width

### Tests

Added integration tests for emoji in table cells, mixed CJK+emoji, and checkmarks.

### markdownlint

As a result of proper emoji width calculation, markdownlint error is no longer triggered: 
`error MD060/table-column-style Table column style [Table pipe does not align with header for style "aligned"]`

---

## Changes Summary

Before: Only CJK support
After: CJK + emoji support using Extended_Pictographic
