### PR TITLE
docs: add FAQ entry for TOC-only usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,26 @@ For other Markdown syntax, you need to install the corresponding extensions from
 
 You can easily manage key bindings with [VS Code's **Keyboard Shortcuts** editor](https://code.visualstudio.com/docs/getstarted/keybindings). (Commands provided by this extension have prefix `markdown.extension`.)
 
+#### Q: Can I use only the Table of Contents feature and disable everything else?
+
+Yes, you can selectively enable/disable features through VS Code settings. To use only the TOC feature while disabling other behaviors:
+
+1. Keep `markdown.extension.toc.updateOnSave` enabled (default: `true`)
+2. Disable other features as needed in your `settings.json`:
+
+   ```json
+   {
+     "markdown.extension.tableFormatter.enabled": false,
+     "markdown.extension.math.enabled": false,
+     "markdown.extension.syntax.plainTheme": true,
+     "markdown.extension.completion.enabled": false,
+     "markdown.extension.preview.autoShowPreviewToSide": false,
+     "markdown.extension.print.onFileSave": false
+   }
+   ```
+
+**Note**: Keyboard shortcuts can be managed through VS Code's [Keyboard Shortcuts editor](https://code.visualstudio.com/docs/getstarted/keybindings) if you need to disable specific key bindings.
+
 #### Q: The extension is unresponsive, causing lag etc. (performance issues)
 
 From experience, there is *a good chance* that the performance issues are caused by *other extensions* (e.g., some spell checker extensions).


### PR DESCRIPTION
Hi @yzhang-gh and team! 👋

I noticed issue #1544 asking about limiting the extension to TOC-only functionality. This is a reasonable request that comes up from time to time, so I went ahead and added a new FAQ entry to help future users.

**Changes:**
- Added new FAQ: "Can I use only the Table of Contents feature and disable everything else?"
- Documented the relevant settings to disable specific features
- Included example configuration in settings.json format

This is a documentation-only change - no code modifications.

Hope this helps! 😊 The extension has been incredibly useful for my daily markdown work. Thanks for maintaining it! 🙏

---
Closes #1544