### PR TITLE
bugfix: no wrapping trailing newline

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -873,6 +873,7 @@
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
             "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -906,6 +907,7 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
             "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -1127,6 +1129,7 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
+            "peer": true,
             "dependencies": {
                 "caniuse-lite": "^1.0.30001587",
                 "electron-to-chromium": "^1.4.668",
@@ -2822,6 +2825,7 @@
             "version": "13.0.2",
             "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-13.0.2.tgz",
             "integrity": "sha512-FtwnEuuK+2yVU7goGn/MJ0WBZMM9ZPgU9spqlFs7/A/pDIUNSOQZhUgOqYCficIuR2QaFnrt8LHqBWsbTAoI5w==",
+            "peer": true,
             "dependencies": {
                 "argparse": "^2.0.1",
                 "entities": "~3.0.1",
@@ -4146,6 +4150,7 @@
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
             "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -4261,6 +4266,7 @@
             "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.91.0.tgz",
             "integrity": "sha512-rzVwlLeBWHJbmgTC/8TvAcu5vpJNII+MelQpylD4jNERPwpBJOE2lEcko1zJX3QJeLjTTAnQxn/OJ8bjDzVQaw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@types/eslint-scope": "^3.7.3",
                 "@types/estree": "^1.0.5",
@@ -4308,6 +4314,7 @@
             "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.9.2.tgz",
             "integrity": "sha512-m3/AACnBBzK/kMTcxWHcZFPrw/eQuY4Df1TxvIWfWM2x7mRqBQCqKEd96oCUa9jkapLBaFfRce33eGDb4Pr7YQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@discoveryjs/json-ext": "^0.5.0",
                 "@webpack-cli/configtest": "^1.1.1",
@@ -5252,7 +5259,8 @@
             "version": "8.11.3",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
             "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "acorn-import-assertions": {
             "version": "1.9.0",
@@ -5275,6 +5283,7 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
             "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -5434,6 +5443,7 @@
             "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.0.tgz",
             "integrity": "sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "caniuse-lite": "^1.0.30001587",
                 "electron-to-chromium": "^1.4.668",
@@ -6664,6 +6674,7 @@
             "version": "13.0.2",
             "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-13.0.2.tgz",
             "integrity": "sha512-FtwnEuuK+2yVU7goGn/MJ0WBZMM9ZPgU9spqlFs7/A/pDIUNSOQZhUgOqYCficIuR2QaFnrt8LHqBWsbTAoI5w==",
+            "peer": true,
             "requires": {
                 "argparse": "^2.0.1",
                 "entities": "~3.0.1",
@@ -7647,7 +7658,8 @@
             "version": "4.5.5",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
             "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "uc.micro": {
             "version": "1.0.6",
@@ -7730,6 +7742,7 @@
             "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.91.0.tgz",
             "integrity": "sha512-rzVwlLeBWHJbmgTC/8TvAcu5vpJNII+MelQpylD4jNERPwpBJOE2lEcko1zJX3QJeLjTTAnQxn/OJ8bjDzVQaw==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "@types/eslint-scope": "^3.7.3",
                 "@types/estree": "^1.0.5",
@@ -7762,6 +7775,7 @@
             "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.9.2.tgz",
             "integrity": "sha512-m3/AACnBBzK/kMTcxWHcZFPrw/eQuY4Df1TxvIWfWM2x7mRqBQCqKEd96oCUa9jkapLBaFfRce33eGDb4Pr7YQ==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "@discoveryjs/json-ext": "^0.5.0",
                 "@webpack-cli/configtest": "^1.1.1",

--- a/src/formatting.ts
+++ b/src/formatting.ts
@@ -24,6 +24,7 @@ export function activate(context: ExtensionContext) {
  * Here we store Regexp to check if the text is the single link.
  */
 const singleLinkRegex: RegExp = createLinkRegex();
+const MAX_LINE_BREAK_LENGTH = 2;
 
 // Return Promise because need to chain operations in unit tests
 
@@ -448,7 +449,11 @@ function styleByWrapping(startPattern: string, endPattern = startPattern) {
             }
         } else {
             // Text selected
-            wrapRange(editor, batchEdit, shifts, newSelections, i, shift, cursorPos, selection, true, startPattern, endPattern);
+            const rangeToWrap = trimTrailingLineBreak(editor, selection);
+            if (!rangeToWrap.end.isEqual(selection.end)) {
+                newSelections[i] = new Selection(selection.start, rangeToWrap.end);
+            }
+            wrapRange(editor, batchEdit, shifts, newSelections, i, shift, cursorPos, rangeToWrap, true, startPattern, endPattern);
         }
     }
 
@@ -525,6 +530,40 @@ function wrapRange(editor: TextEditor, wsEdit: WorkspaceEdit, shifts: [Position,
     }
 
     newSelections[i] = newSelection;
+}
+
+
+/**
+ * Trims any trailing line breaks from the given range.
+ * If the range ends with a carriage return and line feed (\r\n) or a line feed (\n),
+ * a new Range is returned with these characters excluded from the end.
+ * 
+ * @param editor The text editor containing the document.
+ * @param range The range to be trimmed.
+ * @returns A new Range without trailing line breaks, or the original range if none are found.
+ */
+function trimTrailingLineBreak(editor: TextEditor, range: Range): Range {
+    const doc = editor.document;
+    const startOffset = doc.offsetAt(range.start);
+    const endOffset = doc.offsetAt(range.end);
+    if (endOffset <= startOffset) {
+        return range;
+    }
+
+    const tailStartOffset = endOffset - startOffset < MAX_LINE_BREAK_LENGTH ? startOffset : endOffset - MAX_LINE_BREAK_LENGTH;
+    const tail = doc.getText(new Range(doc.positionAt(tailStartOffset), range.end));
+    let trimmedLength = 0;
+    if (tail.endsWith('\r\n')) {
+        trimmedLength = 2;
+    } else if (tail.endsWith('\n')) {
+        trimmedLength = 1;
+    }
+
+    if (trimmedLength === 0) {
+        return range;
+    }
+
+    return new Range(range.start, doc.positionAt(endOffset - trimmedLength));
 }
 
 function isWrapped(text: string, startPattern: string, endPattern: string): boolean {

--- a/src/test/suite/integration/formatting.test.ts
+++ b/src/test/suite/integration/formatting.test.ts
@@ -74,6 +74,27 @@ suite("Formatting.", () => {
         );
     });
 
+    test("Toggle bold. With selection. Excludes trailing newline", () => {
+        return testCommand('markdown.extension.editing.toggleBold',
+            ['text', 'next'], new Selection(0, 0, 1, 0),
+            ['**text**', 'next'], new Selection(0, 0, 0, 8)
+        );
+    });
+
+    test("Toggle bold. With selection. Excludes only final trailing newline in multiline selection", () => {
+        return testCommand('markdown.extension.editing.toggleBold',
+            ['a', 'b', 'c'], new Selection(0, 0, 2, 0),
+            ['**a', 'b**', 'c'], new Selection(0, 0, 1, 5)
+        );
+    });
+
+    test("Toggle bold. With multiline selection without trailing line break. Keeps old behavior", () => {
+        return testCommand('markdown.extension.editing.toggleBold',
+            ['a', 'b'], new Selection(0, 0, 1, 1),
+            ['**a', 'b**'], new Selection(0, 0, 1, 5)
+        );
+    });
+
     test("Toggle bold. With selection. Toggle off", () => {
         return testCommand('markdown.extension.editing.toggleBold',
             ['**text**'], new Selection(0, 0, 0, 8),

--- a/src/zola-slug/Cargo.toml
+++ b/src/zola-slug/Cargo.toml
@@ -32,7 +32,7 @@ split-debuginfo = "off"
 strip = "symbols"
 
 [package.metadata.wasm-pack.profile.release]
-wasm-opt = ['-Os']
+wasm-opt = ['-Os', '--enable-bulk-memory']
 
 [package.metadata.wasm-pack.profile.release.wasm-bindgen]
 debug-js-glue = false


### PR DESCRIPTION
Currently, this project wraps text by enclosing all characters within the selection, **including the newline** at the end of the line. This causes rendering issues because the closing tag ends up **after** the newline (i.e., at the start of the next line), preventing standard Markdown engines from recognizing it as a valid style block.

For example:
<img width="159" height="93" alt="image" src="https://github.com/user-attachments/assets/75263853-521a-4a8c-aa48-a6d429c8e54d" />

When this line is selected, **the trailing LF character is also included**. This leads to the following issue:

<img width="171" height="70" alt="image" src="https://github.com/user-attachments/assets/bc0ae758-28bb-42e2-9d42-60efa65a3932" />

The closing bold marker appears on the next line, breaking the rendering. This issue affects not only bold text but also italics and other styles.

While this is a result of how VS Code handles selections (automatically including the newline), we can programmatically adjust the selection range. 

The purpose of this PR is to **evaluate the final character** in a selection and exclude the newline. The improved behavior is shown below:

<img width="153" height="69" alt="image" src="https://github.com/user-attachments/assets/dd8a4065-d507-41f5-b2a0-ccb05cb358c4" />

<img width="215" height="70" alt="image" src="https://github.com/user-attachments/assets/d7365bea-8e8d-481c-a42e-a6d537e0fc4f" />

This also ensures that multi-line selections avoid wrapping the final newline (even though standard Markdown typically doesn't render multi-line bolding anyway).

<img width="215" height="129" alt="image" src="https://github.com/user-attachments/assets/35eb2fe5-30c4-41a9-92fe-af9915c01b12" />

By the way, when I tried to compile the project, it failed with the information about "wasm-pack require bulk memory", so I added `--enable-bulk-memory` option for wasm-pack.


