### PR TITLE
Add per-TOC heading level override via <!-- levels="x..y" --> comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ All you need for Markdown (keyboard shortcuts, table of contents, auto preview a
 - [FAQ](#faq)
     - [Q: Error "command 'markdown.extension.onXXXKey' not found"](#q-error-command-markdownextensiononxxxkey-not-found)
     - [Q: Which Markdown syntax is supported?](#q-which-markdown-syntax-is-supported)
-    - [Q: This extension has overridden some of my key bindings (e.g. <kbd>Ctrl</kbd> + <kbd>B</kbd>, <kbd>Alt</kbd> + <kbd>C</kbd>)](#q-this-extension-has-overridden-some-of-my-key-bindings-eg-ctrl--b-alt--c)
+    - [Q: This extension has overridden some of my key bindings (e.g. Ctrl + B, Alt + C)](#q-this-extension-has-overridden-some-of-my-key-bindings-eg-ctrl--b-alt--c)
     - [Q: The extension is unresponsive, causing lag etc. (performance issues)](#q-the-extension-is-unresponsive-causing-lag-etc-performance-issues)
 - [Changelog](#changelog)
 - [Latest Development Build](#latest-development-build)
@@ -59,7 +59,7 @@ See full key binding list in the [keyboard shortcuts](#keyboard-shortcuts-1) sec
 
 - To make TOC **compatible with GitHub or GitLab**, set option `slugifyMode` accordingly
 
-- Three ways to **control which headings are present** in the TOC:
+- Four ways to **control which headings are present** in the TOC:
 
   <details>
   <summary>Click to expand</summary>
@@ -69,7 +69,10 @@ See full key binding list in the [keyboard shortcuts](#keyboard-shortcuts-1) sec
 
   2. Use `toc.levels` setting.
 
-  3. You can also use the `toc.omittedFromToc` setting to omit some headings (and their subheadings) from TOC:
+  3. Add `<!-- levels="x..y" -->` directly above a TOC\
+     (where `x..y` will include heading levels `x` to `y` in that TOC, see the `toc.levels` setting).
+
+  4. You can also use the `toc.omittedFromToc` setting to omit some headings (and their subheadings) from TOC:
 
      ```js
      // In your settings.json

--- a/src/test/suite/integration/toc.test.ts
+++ b/src/test/suite/integration/toc.test.ts
@@ -203,7 +203,51 @@ suite("TOC.", () => {
             new Selection(0, 0, 0, 0)
         );
         await resetConfiguration();
+    });
 
+    test("Update (levels 2..3 with levels comment)", async () => {
+        await testCommand("markdown.extension.toc.update",
+            [
+                '# Section 1',
+                '',
+                '## Section 1.1',
+                '',
+                '### Section 1.1.1',
+                '',
+                '#### Section 1.1.1.1',
+                '',
+                '# Section 2',
+                '',
+                '## Section 2.1',
+                '',
+                '<!-- levels="2..3" -->',
+                '- [Section 1.1](#section-11)',
+                '  - [Section 1.1.1](#section-111)',
+                '- [Section 2.1](#section-21)',
+                '  - [Section 2.1.1](#section-211)',
+            ],
+            new Selection(0, 0, 0, 0),
+            [
+                '# Section 1',
+                '',
+                '## Section 1.1',
+                '',
+                '### Section 1.1.1',
+                '',
+                '#### Section 1.1.1.1',
+                '',
+                '# Section 2',
+                '',
+                '## Section 2.1',
+                '',
+                '<!-- levels="2..3" -->',
+                '- [Section 1.1](#section-11)',
+                '  - [Section 1.1.1](#section-111)',
+                '- [Section 2.1](#section-21)',
+                '',
+            ],
+            new Selection(0, 0, 0, 0)
+        );
     });
 
     test("Ordered list (list markers larger than 9)", async () => {

--- a/src/toc.ts
+++ b/src/toc.ts
@@ -54,6 +54,15 @@ export interface IHeading extends IHeadingBase {
 }
 
 /**
+ * Represents a TOC header level range comment.
+ * Eg. `<-- levels="x..y" -->`, where x is startDepth and y is endDepth.
+ */
+interface TOCLevelRangeComment {
+    startDepth: number;
+    endDepth: number;
+}
+
+/**
  * Workspace config
  */
 const docConfig = { tab: '  ', eol: '\r\n' };
@@ -99,11 +108,9 @@ async function updateToc() {
 
     const doc = editor.document;
     const tocRangesAndText = await detectTocRanges(doc);
-    const tocRanges = tocRangesAndText[0];
-    const newToc = tocRangesAndText[1];
 
     await editor.edit(editBuilder => {
-        for (const tocRange of tocRanges) {
+        for (const [tocRange, newToc] of tocRangesAndText) {
             if (tocRange !== null) {
                 const oldToc = doc.getText(tocRange).replace(/\r?\n|\r/g, docConfig.eol);
                 if (oldToc !== newToc) {
@@ -251,12 +258,20 @@ function getProjectExcludedHeadings(doc: TextDocument): readonly Readonly<{ leve
  * Generates the Markdown text representation of the TOC.
  */
 // TODO: Redesign data structure to solve another bunch of bugs.
-async function generateTocText(doc: TextDocument): Promise<string> {
+async function generateTocText(
+    doc: TextDocument,
+    levelRangeComment: TOCLevelRangeComment | null = null
+): Promise<string> {
+    // Get the depth from the TOC's level range comment if it exists.
+    // Otherwise, fallback to the workspace settings.
+    const configStartDepth = levelRangeComment?.startDepth ?? tocConfig.startDepth;
+    const configEndDepth = levelRangeComment?.endDepth ?? tocConfig.endDepth;
+
     const orderedListMarkerIsOne: boolean = workspace.getConfiguration('markdown.extension.orderedList').get<string>('marker') === 'one';
 
     const toc: string[] = [];
     const tocEntries: readonly Readonly<IHeading>[] = getAllTocEntry(doc, { respectMagicCommentOmit: true, respectProjectLevelOmit: true })
-        .filter(i => i.canInToc && i.level >= tocConfig.startDepth && i.level <= tocConfig.endDepth); // Filter out excluded headings.
+        .filter(i => i.canInToc && i.level >= configStartDepth && i.level <= configEndDepth); // Filter out excluded headings.
 
     if (tocEntries.length === 0) {
         return '';
@@ -265,7 +280,7 @@ async function generateTocText(doc: TextDocument): Promise<string> {
     // The actual level range of a document can be smaller than settings. So we need to calculate the real start level.
     const startDepth = Math.max(tocConfig.startDepth, Math.min(...tocEntries.map(h => h.level)));
     // Order counter for each heading level (from startDepth to endDepth), used only for ordered list
-    const orderCounter: number[] = new Array(tocConfig.endDepth - startDepth + 1).fill(0);
+    const orderCounter: number[] = new Array(configEndDepth - startDepth + 1).fill(0);
 
     tocEntries.forEach(entry => {
         const relativeLevel = entry.level - startDepth;
@@ -300,7 +315,7 @@ async function generateTocText(doc: TextDocument): Promise<string> {
  * If no TOC is found, returns an empty array.
  * @param doc a TextDocument
  */
-async function detectTocRanges(doc: TextDocument): Promise<[Array<Range>, string]> {
+async function detectTocRanges(doc: TextDocument): Promise<Array<[Range, string]>> {
     const docTokens = (await mdEngine.getDocumentToken(doc)).tokens;
     /**
      * `[beginLineIndex, endLineIndex, openingTokenIndex]`
@@ -318,8 +333,7 @@ async function detectTocRanges(doc: TextDocument): Promise<[Array<Range>, string
         return result;
     }, []);
 
-    const tocRanges: Range[] = [];
-    const newTocText = await generateTocText(doc);
+    const tocRanges: [Range, string][] = [];
 
     for (const item of candidateLists) {
         const beginLineIndex = item[0];
@@ -332,6 +346,24 @@ async function detectTocRanges(doc: TextDocument): Promise<[Array<Range>, string
             && doc.lineAt(beginLineIndex - 1).text === '<!-- no toc -->'
         ) {
             continue;
+        }
+
+        // <!-- levels="x..y" --> comment
+
+        function parseLevelRangeComment(input: string): TOCLevelRangeComment | null {
+            // See loadTocConfig(editor:)
+            const match = input.match(/^<!--\s*levels="(?<x>[1-6])\.\.(?<y>[1-6])"\s*-->$/);
+            if (!match) return null;
+
+            const { x, y } = match.groups as { x: string; y: string };
+            return { startDepth: Number(x), endDepth: Number(y) };
+        }
+
+        let levelRangeComment: TOCLevelRangeComment | null = null;
+
+        if (beginLineIndex > 0) {
+            const previousLine = doc.lineAt(beginLineIndex - 1).text;
+            levelRangeComment = parseLevelRangeComment(previousLine);
         }
 
         // Check the first list item to see if it could be a TOC.
@@ -379,14 +411,17 @@ async function detectTocRanges(doc: TextDocument): Promise<[Array<Range>, string
             endLineIndex--;
         }
 
+        // generate TOC text, considering the TOC's level range comment if exists
+        const newTocText = await generateTocText(doc, levelRangeComment);
+
         const finalRange = new Range(new Position(beginLineIndex, 0), new Position(endLineIndex, 0));
         const listText = doc.getText(finalRange);
         if (radioOfCommonPrefix(newTocText, listText) + stringSimilarity.compareTwoStrings(newTocText, listText) > 0.5) {
-            tocRanges.push(finalRange);
+            tocRanges.push([finalRange, newTocText]);
         }
     }
 
-    return [tocRanges, newTocText];
+    return tocRanges;
 }
 
 function commonPrefixLength(s1: string, s2: string): number {
@@ -704,9 +739,7 @@ class TocCodeLensProvider implements CodeLensProvider {
 
         const lenses: CodeLens[] = [];
         return detectTocRanges(document).then(tocRangesAndText => {
-            const tocRanges = tocRangesAndText[0];
-            const newToc = tocRangesAndText[1];
-            for (let tocRange of tocRanges) {
+            for (let [tocRange, newToc] of tocRangesAndText) {
                 let status = document.getText(tocRange).replace(/\r?\n|\r/g, docConfig.eol) === newToc ? 'up to date' : 'out of date';
                 lenses.push(new CodeLens(tocRange, {
                     arguments: [],

--- a/src/zola-slug/Cargo.toml
+++ b/src/zola-slug/Cargo.toml
@@ -32,7 +32,8 @@ split-debuginfo = "off"
 strip = "symbols"
 
 [package.metadata.wasm-pack.profile.release]
-wasm-opt = ['-Os']
+# Rust's wasm32 target now emits bulk memory ops by default
+wasm-opt = ['-Os', '--enable-bulk-memory']
 
 [package.metadata.wasm-pack.profile.release.wasm-bindgen]
 debug-js-glue = false


### PR DESCRIPTION
## Summary

Adds a fourth way to control which headings appear in a table of contents: a `<!-- levels="x..y" -->` HTML comment placed directly above a TOC. When present, it overrides the global/workspace `markdown.extension.toc.levels` setting for that TOC only, letting a single document contain multiple TOCs with different depth ranges.

See: #208, #1078, #1414, [#1563](https://github.com/yzhang-gh/vscode-markdown/issues/1563#issuecomment-4481572991).

Example:

```markdown
<!-- levels="2..3" -->
- [Section 1.1](#section-11)
  - [Section 1.1.1](#section-111)
```

## Changes

- [src/toc.ts](https://github.com/yzhang-gh/vscode-markdown/pull/1574/changes#diff-219409a48a8c50c01f142c101c7ca0bf7f4081d1b2e42db15925c2c597b17c30): parse the `levels="x..y"` comment on the line preceding each detected TOC and pass it into `generateTocText`. Refactored `detectTocRanges` to return `Array<[Range, string]>` so each TOC can hold its own generated text (previously a single shared string was reused for every TOC in the document).
- [src/test/suite/integration/toc.test.ts](https://github.com/yzhang-gh/vscode-markdown/pull/1574/changes#diff-437d24889c3186c2c1eb9bcd27f6c51fe2a039ce2212895c69ca8cedc431fc24): integration test for the `levels="2..3"` case.
- [README.md](https://github.com/yzhang-gh/vscode-markdown/pull/1574/changes#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5): document the new option under the "control which headings are present" section. The `<kbd>`-tag change in the FAQ TOC entry is just the result of regenerating the TOC with this extension and is incidental.

## Build fix

- [src/zola-slug/Cargo.toml](https://github.com/yzhang-gh/vscode-markdown/pull/1574/changes#diff-502483f6e491318161393c49cdbab6823edca8e2f7b1e135bfb73f38dac75a12): add `--enable-bulk-memory` to the `wasm-opt` flags. Without this the release build of `zola-slug` fails on current Rust toolchains, since the `wasm32` target now emits bulk memory ops by default and the old `wasm-opt` invocation rejects them.